### PR TITLE
docs: bootstrap do zero — corrigir pré-requisitos do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Este repositório faz parte de um conjunto de 5 repos:
 | Linguagem    | TypeScript 5.x (strict mode) |
 | Roteamento   | React Router DOM             |
 | HTTP Client  | Axios                        |
-| Autenticação | Auth0 (OAuth 2.0)            |
+| Autenticação | JWT próprio (HS256)          |
 | i18n         | i18next (pt-BR / en-US)      |
 
 ## Pré-requisitos
@@ -35,6 +35,7 @@ Este repositório faz parte de um conjunto de 5 repos:
 - Node.js >= 20 LTS
 - npm >= 10
 - Backend (petcard-api) rodando em http://localhost:3000
+- GitHub Personal Access Token com escopo `read:packages` (para baixar `@petcardorg/shared` do GitHub Packages)
 
 ## Instalação
 
@@ -43,14 +44,18 @@ Este repositório faz parte de um conjunto de 5 repos:
 git clone https://github.com/PetCardOrg/petcard-web.git
 cd petcard-web
 
-# 2. Instale as dependências
+# 2. Autentique no GitHub Packages (necessário para @petcardorg/shared)
+# Crie um token em https://github.com/settings/tokens com escopo read:packages
+export NODE_AUTH_TOKEN=<seu_personal_access_token>
+
+# 3. Instale as dependências
 npm install
 
-# 3. Configure as variáveis de ambiente
+# 4. Configure as variáveis de ambiente
 cp .env.example .env
-# Edite o .env com a URL da API e credenciais Auth0
+# Ajuste VITE_API_URL se a API não estiver em http://localhost:3000
 
-# 4. Inicie o servidor de desenvolvimento
+# 5. Inicie o servidor de desenvolvimento
 npm run dev
 # Aplicação disponível em http://localhost:5173
 ```
@@ -66,7 +71,7 @@ npm run dev
 
 ## Funcionalidades
 
-- Login do veterinário via Auth0
+- Login do veterinário via JWT próprio
 - Dashboard com lista de pets atendidos
 - Perfil do pet com histórico completo de saúde
 - Formulário de nota clínica (escrita reversa)


### PR DESCRIPTION
## Contexto

Dia 3 do plano de ação da auditoria (bootstrap do zero confiável). Endereça o Risco de Apresentação #2 ("setup do zero falha") na parte do **petcard-web**.

## Mudanças (README)

- **Auth0 removido** (3 menções: tabela de stack, comentário do `.env`, funcionalidades) — Auth0 foi abandonado (M0-#7); autenticação é **JWT próprio (HS256)**
- adicionada a etapa de **`NODE_AUTH_TOKEN` (`read:packages`)** antes do `npm install` — o `.npmrc` consome `@petcardorg/shared` do GitHub Packages, então sem o token o `npm install` falha em máquina limpa
- comentário do `.env` corrigido (ajustar `VITE_API_URL`, sem "credenciais Auth0")

Sem mudança de código — só documentação de setup.