### PR TITLE
chore: alinhar @petcardorg/shared em ^0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "petcard-web",
       "version": "0.0.0",
       "dependencies": {
-        "@petcardorg/shared": "^0.7.0",
+        "@petcardorg/shared": "^0.9.0",
         "html5-qrcode": "^2.3.8",
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -611,9 +611,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.7.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.7.0/9ea663eb3e7fa3974c4c73d75f843fef29eec12d",
-      "integrity": "sha512-Ya2yrAez3T4jONE+P5xA5NH185ZUXZXaYOIICrBnGtakuNYlMHru/ornEpAyAVlVfFzKGrwQmfyjzWwy3G0wDw==",
+      "version": "0.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.9.0/3d77c7b90a05ab9f9058739a3ea70d94f807a2db",
+      "integrity": "sha512-Uz4vaqyOMw1LZ5guOHrJFxoXXDYAlcQCJndbgHpCL3pjYBDszi3vYl3PMlo1UPfnRkdURY5pFZymUh74GwLAhg==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "*.{ts,tsx,json,css,md}": "prettier --write"
   },
   "dependencies": {
-    "@petcardorg/shared": "^0.7.0",
+    "@petcardorg/shared": "^0.9.0",
     "html5-qrcode": "^2.3.8",
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",


### PR DESCRIPTION
## Contexto
Dia 4 da auditoria (Segurança e contratos), achado #6 (🟡).

Resolve o **skew de versão** do contrato compartilhado `@petcardorg/shared` e deixa de manter o release `0.9.0` órfão (publicado no M5, mas não consumido).

- api: `^0.8.0` → `^0.9.0`
- web: `^0.7.0` → `^0.9.0`
- mobile: `^0.8.0` → `^0.9.0`

`package-lock.json` atualizado junto. Os DTOs de M5 (veterinário/nota clínica) já estão no pacote; cópias locais no backend são **duplicação consciente** (nomenclatura própria do domínio, ex.: `CreateVetNoteDto`), documentada no DAS §5.2.

## Validação
- api: `tsc` ✅, `jest` 151/151 ✅
- web: `npm run build` ✅
- mobile: `tsc --noEmit` ✅