### PR TITLE
refactor: PC-006 - consumir CreateNotaClinicaDto do shared

### DIFF
--- a/src/pages/VetPetProfile/VetPetProfilePage.tsx
+++ b/src/pages/VetPetProfile/VetPetProfilePage.tsx
@@ -17,10 +17,8 @@ import {
   fetchPetProfile,
   createClinicalNote,
 } from "../../services/pet-profile.service";
-import type {
-  PetProfileData,
-  CreateClinicalNoteDto,
-} from "../../services/pet-profile.service";
+import type { PetProfileData } from "../../services/pet-profile.service";
+import type { CreateNotaClinicaDto } from "@petcardorg/shared";
 import { ApiError } from "../../services/api";
 import "./VetPetProfilePage.css";
 
@@ -137,7 +135,7 @@ export function VetPetProfilePage() {
   >("timeline");
 
   const [showForm, setShowForm] = useState(false);
-  const [formData, setFormData] = useState<CreateClinicalNoteDto>({
+  const [formData, setFormData] = useState<CreateNotaClinicaDto>({
     diagnostico: "",
   });
   const [submitting, setSubmitting] = useState(false);
@@ -190,7 +188,7 @@ export function VetPetProfilePage() {
     setSubmitting(true);
     setSubmitError(null);
     try {
-      const dto: CreateClinicalNoteDto = {
+      const dto: CreateNotaClinicaDto = {
         diagnostico: formData.diagnostico.trim(),
       };
       if (formData.prescricao?.trim()) {

--- a/src/services/pet-profile.service.ts
+++ b/src/services/pet-profile.service.ts
@@ -1,3 +1,4 @@
+import type { CreateNotaClinicaDto } from "@petcardorg/shared";
 import { apiFetch } from "./api";
 
 export interface PetDetail {
@@ -58,16 +59,10 @@ export interface PetProfileData {
   clinicalNotes: ClinicalNote[];
 }
 
-export interface CreateClinicalNoteDto {
-  diagnostico: string;
-  prescricao?: string;
-  observacoes?: string;
-}
-
 export async function createClinicalNote(
   token: string,
   petId: string,
-  dto: CreateClinicalNoteDto,
+  dto: CreateNotaClinicaDto,
 ): Promise<ClinicalNote> {
   return apiFetch<ClinicalNote>(`/pets/${petId}/clinical-notes`, {
     method: "POST",


### PR DESCRIPTION
## Contexto
Achado #6 da auditoria: DTOs do M5 duplicados localmente em vez de consumir `@petcardorg/shared`. Complemento do PR de mesmo tema na API.

## O que muda
- Remove a interface local `CreateClinicalNoteDto` (`pet-profile.service.ts`).
- Passa a usar `CreateNotaClinicaDto` de `@petcardorg/shared` no service e no `VetPetProfilePage` (mesma forma: `diagnostico`, `prescricao?`, `observacoes?`; o `google_place_id?` extra do shared é opcional e não é setado pelo formulário).

## O que permanece local (de propósito)
As interfaces de **resposta** (`ClinicalNote`, `PetDetail`, `VaccineRecord`, etc.) seguem locais por serem *view models* da web — subconjunto em snake_case, datas como `string` — diferentes dos response DTOs do shared.

## Validação
- `npm run build` (tsc -b + vite) ✅ (aviso de bundle >500kB é pré-existente/cosmético)
- `eslint` ✅