### PR TITLE
feat: aviso e verificação de CRMV na tela do pet (api#113)

### DIFF
--- a/src/i18n/locales/en-US/common.json
+++ b/src/i18n/locales/en-US/common.json
@@ -142,6 +142,14 @@
       "submitting": "Saving...",
       "cancel": "Cancel",
       "submitError": "Failed to save clinical note. Please try again."
+    },
+    "crmv": {
+      "title": "CRMV not verified",
+      "blocked": "Your CRMV must be verified to access clinical data.",
+      "verify": "Verify my CRMV",
+      "verifying": "Verifying...",
+      "refused": "The registration was not accepted (status: {{situacao}}). Check the CRMV in your profile.",
+      "failed": "Could not verify your CRMV right now. Please try again."
     }
   },
   "vetScan": {

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -142,6 +142,14 @@
       "submitting": "Salvando...",
       "cancel": "Cancelar",
       "submitError": "Erro ao salvar a nota clínica. Tente novamente."
+    },
+    "crmv": {
+      "title": "CRMV não verificado",
+      "blocked": "Seu CRMV precisa estar verificado para acessar dados clínicos.",
+      "verify": "Verificar meu CRMV",
+      "verifying": "Verificando...",
+      "refused": "O registro não foi aceito (situação: {{situacao}}). Confira o CRMV no seu cadastro.",
+      "failed": "Não foi possível verificar seu CRMV agora. Tente novamente."
     }
   },
   "vetScan": {

--- a/src/pages/VetPetProfile/VetPetProfilePage.css
+++ b/src/pages/VetPetProfile/VetPetProfilePage.css
@@ -643,3 +643,11 @@
     font-size: 0.75rem;
   }
 }
+
+/* Bloqueio por CRMV não verificado (api#113) */
+.vet-crmv-message {
+  color: var(--color-muted, #6b7c85);
+  margin: 0 0 16px;
+  max-width: 42ch;
+  text-align: center;
+}

--- a/src/pages/VetPetProfile/VetPetProfilePage.test.tsx
+++ b/src/pages/VetPetProfile/VetPetProfilePage.test.tsx
@@ -23,11 +23,18 @@ vi.mock("../../services/pet-profile.service", () => ({
   createClinicalNote: vi.fn(),
 }));
 
+vi.mock("../../services/crmv.service", () => ({
+  verificarCrmv: vi.fn(),
+}));
+
 import {
   createClinicalNote,
   fetchPetProfile,
 } from "../../services/pet-profile.service";
 
+import { verificarCrmv } from "../../services/crmv.service";
+
+const verificarCrmvMock = vi.mocked(verificarCrmv);
 const fetchProfileMock = vi.mocked(fetchPetProfile);
 const createNoteMock = vi.mocked(createClinicalNote);
 
@@ -165,5 +172,76 @@ describe("VetPetProfilePage", () => {
         "Erro ao salvar a nota clínica. Tente novamente.",
       ),
     ).toBeInTheDocument();
+  });
+});
+
+describe("VetPetProfilePage — bloqueio por CRMV (api#113)", () => {
+  const erroCrmv = new ApiError(
+    403,
+    "Forbidden",
+    "Seu CRMV precisa estar verificado para acessar dados clínicos.",
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mostra o aviso acionável em vez do erro genérico", async () => {
+    fetchProfileMock.mockRejectedValue(erroCrmv);
+
+    render(<VetPetProfilePage />);
+
+    expect(
+      await screen.findByText(/CRMV precisa estar verificado/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /verificar meu crmv/i }),
+    ).toBeInTheDocument();
+    expect(logoutMock).not.toHaveBeenCalled();
+  });
+
+  it("recarrega o perfil quando a verificação aprova", async () => {
+    fetchProfileMock.mockRejectedValueOnce(erroCrmv);
+    verificarCrmvMock.mockResolvedValue({ verified: true, situacao: "Ativo" });
+    fetchProfileMock.mockResolvedValueOnce(buildProfile());
+
+    render(<VetPetProfilePage />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /verificar meu crmv/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Rex").length).toBeGreaterThan(0),
+    );
+    expect(fetchProfileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("explica quando o registro é recusado", async () => {
+    fetchProfileMock.mockRejectedValue(erroCrmv);
+    verificarCrmvMock.mockResolvedValue({
+      verified: false,
+      situacao: "Suspenso",
+    });
+
+    render(<VetPetProfilePage />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /verificar meu crmv/i }),
+    );
+
+    expect(await screen.findByText(/Suspenso/)).toBeInTheDocument();
+  });
+
+  it("não confunde 403 de posse com bloqueio de CRMV", async () => {
+    fetchProfileMock.mockRejectedValue(
+      new ApiError(403, "Forbidden", "Pet de outro tutor"),
+    );
+
+    render(<VetPetProfilePage />);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /verificar meu crmv/i }),
+      ).not.toBeInTheDocument(),
+    );
   });
 });

--- a/src/pages/VetPetProfile/VetPetProfilePage.tsx
+++ b/src/pages/VetPetProfile/VetPetProfilePage.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../services/pet-profile.service";
 import type { PetProfileData } from "../../services/pet-profile.service";
 import type { CreateNotaClinicaDto } from "@petcardorg/shared";
+import { verificarCrmv } from "../../services/crmv.service";
 import { ApiError } from "../../services/api";
 import "./VetPetProfilePage.css";
 
@@ -130,6 +131,10 @@ export function VetPetProfilePage() {
   const [data, setData] = useState<PetProfileData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  // Bloqueio por CRMV não verificado (api#113): erro acionável, não falha genérica.
+  const [crmvBloqueado, setCrmvBloqueado] = useState<string | null>(null);
+  const [verificandoCrmv, setVerificandoCrmv] = useState(false);
+  const [erroVerificacao, setErroVerificacao] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<
     "timeline" | "vaccines" | "dewormings" | "medications" | "notes"
   >("timeline");
@@ -145,6 +150,7 @@ export function VetPetProfilePage() {
     if (!token || !id) return;
     setLoading(true);
     setError(false);
+    setCrmvBloqueado(null);
     try {
       const result = await fetchPetProfile(token, id);
       setData(result);
@@ -153,11 +159,41 @@ export function VetPetProfilePage() {
         logout();
         return;
       }
+      if (err instanceof ApiError && err.isCrmvNaoVerificado) {
+        setCrmvBloqueado(err.detail ?? t("petProfile.crmv.blocked"));
+        return;
+      }
       setError(true);
     } finally {
       setLoading(false);
     }
-  }, [token, id, logout]);
+  }, [token, id, logout, t]);
+
+  const handleVerificarCrmv = useCallback(async () => {
+    if (!token) return;
+    setVerificandoCrmv(true);
+    setErroVerificacao(null);
+    try {
+      const status = await verificarCrmv(token);
+      if (status.verified) {
+        await load();
+      } else {
+        setErroVerificacao(
+          t("petProfile.crmv.refused", {
+            situacao: status.situacao ?? "-",
+          }),
+        );
+      }
+    } catch (err) {
+      setErroVerificacao(
+        err instanceof ApiError && err.detail
+          ? err.detail
+          : t("petProfile.crmv.failed"),
+      );
+    } finally {
+      setVerificandoCrmv(false);
+    }
+  }, [token, load, t]);
 
   useEffect(() => {
     load();
@@ -236,6 +272,28 @@ export function VetPetProfilePage() {
                 <div key={i} className="vet-pet-profile-skeleton-item" />
               ))}
             </div>
+          </div>
+        )}
+
+        {crmvBloqueado && !loading && (
+          <div className="vet-pet-profile-state-card">
+            <div className="vet-pet-profile-state-icon vet-pet-profile-error-icon">
+              <IoAlertCircle size={36} color="#e63946" />
+            </div>
+            <h3>{t("petProfile.crmv.title")}</h3>
+            <p className="vet-crmv-message">{crmvBloqueado}</p>
+            <button
+              type="button"
+              onClick={handleVerificarCrmv}
+              disabled={verificandoCrmv}
+            >
+              {verificandoCrmv
+                ? t("petProfile.crmv.verifying")
+                : t("petProfile.crmv.verify")}
+            </button>
+            {erroVerificacao && (
+              <p className="vet-note-form-error">{erroVerificacao}</p>
+            )}
           </div>
         )}
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -29,7 +29,21 @@ export async function apiFetch<T>(
   });
 
   if (!res.ok) {
-    throw new ApiError(res.status, res.statusText);
+    // A mensagem do corpo distingue motivos que compartilham o mesmo status —
+    // um 403 por CRMV não verificado pede ação diferente de um 403 por posse.
+    let detail: string | undefined;
+    try {
+      const body: unknown = await res.clone().json();
+      const message = (body as { message?: unknown })?.message;
+      detail = Array.isArray(message)
+        ? message.join(", ")
+        : typeof message === "string"
+          ? message
+          : undefined;
+    } catch {
+      detail = undefined;
+    }
+    throw new ApiError(res.status, res.statusText, detail);
   }
 
   if (res.status === 204) {
@@ -41,10 +55,18 @@ export async function apiFetch<T>(
 
 export class ApiError extends Error {
   readonly status: number;
+  /** Mensagem devolvida pela API, quando houver. */
+  readonly detail?: string;
 
-  constructor(status: number, statusText: string) {
-    super(`${status} ${statusText}`);
+  constructor(status: number, statusText: string, detail?: string) {
+    super(detail ?? `${status} ${statusText}`);
     this.name = "ApiError";
     this.status = status;
+    this.detail = detail;
+  }
+
+  /** 403 causado por CRMV não verificado (api#113), e não por falta de posse. */
+  get isCrmvNaoVerificado(): boolean {
+    return this.status === 403 && /CRMV/i.test(this.detail ?? "");
   }
 }

--- a/src/services/crmv.service.test.ts
+++ b/src/services/crmv.service.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchCrmvStatus, verificarCrmv } from "./crmv.service";
+import { ApiError } from "./api";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function ok(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+    clone() {
+      return this;
+    },
+  };
+}
+
+describe("crmv.service", () => {
+  it("consulta a situação do CRMV", async () => {
+    fetchMock.mockResolvedValue(ok({ verified: true, situacao: "Ativo" }));
+
+    await expect(fetchCrmvStatus("jwt")).resolves.toEqual({
+      verified: true,
+      situacao: "Ativo",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/veterinarios/me/crmv");
+    expect(init.headers.Authorization).toBe("Bearer jwt");
+  });
+
+  it("dispara a verificação sem force por padrão", async () => {
+    fetchMock.mockResolvedValue(ok({ verified: true }));
+
+    await verificarCrmv("jwt");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("POST");
+    expect(String(url)).not.toContain("force");
+  });
+
+  it("passa force=true quando pedido", async () => {
+    fetchMock.mockResolvedValue(ok({ verified: true }));
+
+    await verificarCrmv("jwt", true);
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain("force=true");
+  });
+});
+
+describe("ApiError", () => {
+  it("carrega a mensagem devolvida pela API", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      json: () => Promise.resolve({ message: "CRMV precisa estar verificado" }),
+      clone() {
+        return this;
+      },
+    });
+
+    const erro = await verificarCrmv("jwt").catch((e: unknown) => e);
+
+    expect(erro).toBeInstanceOf(ApiError);
+    expect((erro as ApiError).detail).toMatch(/CRMV/);
+    expect((erro as ApiError).isCrmvNaoVerificado).toBe(true);
+  });
+
+  it("não confunde outro 403 com bloqueio de CRMV", () => {
+    expect(
+      new ApiError(403, "Forbidden", "Pet de outro tutor").isCrmvNaoVerificado,
+    ).toBe(false);
+  });
+
+  it("tolera corpo de erro sem JSON", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.reject(new Error("não é json")),
+      clone() {
+        return this;
+      },
+    });
+
+    const erro = (await verificarCrmv("jwt").catch(
+      (e: unknown) => e,
+    )) as ApiError;
+
+    expect(erro.status).toBe(500);
+    expect(erro.detail).toBeUndefined();
+  });
+});

--- a/src/services/crmv.service.ts
+++ b/src/services/crmv.service.ts
@@ -1,0 +1,27 @@
+import { apiFetch } from "./api";
+
+export interface CrmvStatus {
+  verified: boolean;
+  situacao?: string;
+  verified_at?: string;
+}
+
+export function fetchCrmvStatus(token: string): Promise<CrmvStatus> {
+  return apiFetch<CrmvStatus>("/veterinarios/me/crmv", { token });
+}
+
+/**
+ * Dispara a verificação do CRMV na base externa (api#113).
+ *
+ * A consulta é paga por chamada: sem `force`, a API reaproveita a verificação
+ * anterior enquanto ela estiver dentro do prazo.
+ */
+export function verificarCrmv(
+  token: string,
+  force = false,
+): Promise<CrmvStatus> {
+  return apiFetch<CrmvStatus>(
+    `/veterinarios/me/crmv/verificar${force ? "?force=true" : ""}`,
+    { method: "POST", token },
+  );
+}


### PR DESCRIPTION
Acompanha `petcard-api#123`. Depende de `petcard-shared#53` (0.11.0).

## Por quê

A api#113 passou a exigir CRMV verificado nos endpoints de dados clínicos que **esta tela consome** (`/pets/:id/clinical-notes` e `/pets/:id/medications`). Sem esta mudança, o veterinário não verificado veria só o erro genérico de carga — sem saber o motivo nem o que fazer.

## O que muda

Quando a API responde **403 por CRMV**, a tela mostra um aviso próprio com o motivo e um botão **"Verificar meu CRMV"**, que chama `POST /veterinarios/me/crmv/verificar` e recarrega o perfil se a verificação aprovar. O ciclo inteiro — bloqueado → verificar → liberado — acontece na interface.

Se o registro for recusado, a tela informa a situação devolvida (ex.: "Suspenso") em vez de repetir o bloqueio sem explicação.

## `ApiError` passou a carregar a mensagem

Antes ele guardava só o status. Sem o corpo da resposta não dá para separar **403 por CRMV** de **403 por posse do pet** — situações que pedem reações diferentes. O `detail` é extraído com tolerância a corpo não-JSON.

## Testes

10 na página (4 novos, incluindo o caso que garante que um 403 comum **não** vira aviso de CRMV) e 6 no serviço/`ApiError`.

Cobertura 82.7 / 77.85 / 80.64 / 82.7 — acima da catraca 80/75/78/80, e acima do patamar anterior.