### PR TITLE
feat: tela de cadastro de veterinário (api#124)

### DIFF
--- a/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -12,6 +12,7 @@ function renderWithAuth(auth: Partial<AuthContextValue>) {
     user: null,
     loading: false,
     login: async () => {},
+    register: async () => true,
     logout: () => {},
     ...auth,
   };

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -6,15 +6,18 @@ import { useAuth } from "../hooks/useAuth";
 
 vi.mock("../services/auth.service", () => ({
   loginVeterinario: vi.fn(),
+  registerVeterinario: vi.fn(),
   getVeterinarioProfile: vi.fn(),
 }));
 
 import {
   getVeterinarioProfile,
   loginVeterinario,
+  registerVeterinario,
 } from "../services/auth.service";
 
 const loginMock = vi.mocked(loginVeterinario);
+const registerMock = vi.mocked(registerVeterinario);
 const profileMock = vi.mocked(getVeterinarioProfile);
 
 const TOKEN_KEY = "petcard-vet-token";
@@ -34,6 +37,7 @@ describe("AuthProvider / useAuth", () => {
   beforeEach(() => {
     localStorage.clear();
     loginMock.mockReset();
+    registerMock.mockReset();
     profileMock.mockReset();
   });
 
@@ -64,6 +68,30 @@ describe("AuthProvider / useAuth", () => {
     });
     expect(localStorage.getItem(TOKEN_KEY)).toBe("jwt-1");
     expect(result.current.token).toBe("jwt-1");
+    expect(result.current.user).toEqual(vetUser);
+  });
+
+  it("register autentica direto e informa se o CRMV saiu verificado", async () => {
+    registerMock.mockResolvedValue({
+      access_token: "jwt-novo",
+      user: vetUser,
+      crmv_verificado: false,
+    });
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    let verificado: boolean | undefined;
+    await act(async () => {
+      verificado = await result.current.register({
+        nome: "Dra. Camila",
+        email: "vet@petcard.com",
+        password: "senha123",
+        crmv: "CRMV-CE-1234",
+      });
+    });
+
+    // Sem verificação o vet ainda entra; o bloqueio aparece na tela do pet.
+    expect(verificado).toBe(false);
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("jwt-novo");
     expect(result.current.user).toEqual(vetUser);
   });
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
-import type { VetUser } from "../services/auth.service";
+import type { VetRegisterRequest, VetUser } from "../services/auth.service";
 import {
   loginVeterinario,
+  registerVeterinario,
   getVeterinarioProfile,
 } from "../services/auth.service";
 import { AuthContext } from "./auth-context";
@@ -49,14 +50,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const register = useCallback(async (dto: VetRegisterRequest) => {
+    const response = await registerVeterinario(dto);
+    localStorage.setItem(TOKEN_KEY, response.access_token);
+    setState({
+      token: response.access_token,
+      user: response.user,
+      loading: false,
+    });
+    return response.crmv_verificado;
+  }, []);
+
   const logout = useCallback(() => {
     localStorage.removeItem(TOKEN_KEY);
     setState({ token: null, user: null, loading: false });
   }, []);
 
   const value = useMemo(
-    () => ({ ...state, login, logout }),
-    [state, login, logout],
+    () => ({ ...state, login, register, logout }),
+    [state, login, register, logout],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import type { VetUser } from "../services/auth.service";
+import type { VetRegisterRequest, VetUser } from "../services/auth.service";
 
 interface AuthState {
   token: string | null;
@@ -9,6 +9,8 @@ interface AuthState {
 
 export interface AuthContextValue extends AuthState {
   login: (email: string, password: string) => Promise<void>;
+  /** Cadastra e já autentica. Devolve se o CRMV saiu verificado da consulta. */
+  register: (dto: VetRegisterRequest) => Promise<boolean>;
   logout: () => void;
 }
 

--- a/src/i18n/locales/en-US/common.json
+++ b/src/i18n/locales/en-US/common.json
@@ -77,7 +77,33 @@
     "submit": "Sign in",
     "submitting": "Signing in...",
     "invalidCredentials": "Invalid email or password.",
-    "genericError": "Login failed. Please try again."
+    "genericError": "Login failed. Please try again.",
+    "noAccount": "No account yet?",
+    "goToRegister": "Create account"
+  },
+  "vetRegister": {
+    "subtitle": "Create veterinarian account",
+    "nome": "Full name",
+    "nomePlaceholder": "Dr. Camila Ferreira",
+    "crmv": "CRMV",
+    "crmvPlaceholder": "CRMV-SP 12345",
+    "crmvHint": "We validate your professional registry during sign-up.",
+    "email": "Email",
+    "emailPlaceholder": "your@email.com",
+    "telefone": "Phone (optional)",
+    "telefonePlaceholder": "(11) 99999-0000",
+    "password": "Password",
+    "passwordPlaceholder": "At least 6 characters",
+    "confirm": "Confirm password",
+    "confirmPlaceholder": "Type the password again",
+    "submit": "Create account",
+    "submitting": "Creating account...",
+    "passwordMismatch": "Passwords do not match.",
+    "duplicate": "An account with this email or CRMV already exists.",
+    "invalid": "Please check the information provided.",
+    "genericError": "Could not create the account. Please try again.",
+    "hasAccount": "Already have an account?",
+    "goToLogin": "Sign in"
   },
   "vetDashboard": {
     "title": "Attended Pets",
@@ -101,7 +127,8 @@
       "prev": "Previous",
       "next": "Next",
       "page": "Page {{current}} of {{total}}"
-    }
+    },
+    "crmvNaoVerificado": "We could not confirm your CRMV right now. You can use the system, but pets' clinical history only opens after verification — you can try again when opening a pet."
   },
   "petProfile": {
     "title": "Pet Profile",

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -77,7 +77,33 @@
     "submit": "Entrar",
     "submitting": "Entrando...",
     "invalidCredentials": "E-mail ou senha inválidos.",
-    "genericError": "Erro ao fazer login. Tente novamente."
+    "genericError": "Erro ao fazer login. Tente novamente.",
+    "noAccount": "Não tem conta?",
+    "goToRegister": "Criar conta"
+  },
+  "vetRegister": {
+    "subtitle": "Criar conta de veterinário",
+    "nome": "Nome completo",
+    "nomePlaceholder": "Dra. Camila Ferreira",
+    "crmv": "CRMV",
+    "crmvPlaceholder": "CRMV-SP 12345",
+    "crmvHint": "Validamos seu registro no conselho durante o cadastro.",
+    "email": "E-mail",
+    "emailPlaceholder": "seu@email.com",
+    "telefone": "Telefone (opcional)",
+    "telefonePlaceholder": "(11) 99999-0000",
+    "password": "Senha",
+    "passwordPlaceholder": "Mínimo de 6 caracteres",
+    "confirm": "Confirmar senha",
+    "confirmPlaceholder": "Digite a senha novamente",
+    "submit": "Criar conta",
+    "submitting": "Criando conta...",
+    "passwordMismatch": "As senhas não coincidem.",
+    "duplicate": "Já existe uma conta com esse e-mail ou CRMV.",
+    "invalid": "Verifique os dados informados.",
+    "genericError": "Erro ao criar a conta. Tente novamente.",
+    "hasAccount": "Já tem conta?",
+    "goToLogin": "Entrar"
   },
   "vetDashboard": {
     "title": "Pets Atendidos",
@@ -101,7 +127,8 @@
       "prev": "Anterior",
       "next": "Próxima",
       "page": "Página {{current}} de {{total}}"
-    }
+    },
+    "crmvNaoVerificado": "Não conseguimos confirmar seu CRMV agora. Você já pode usar o sistema, mas o histórico clínico dos pets só abre depois da verificação — é possível tentar de novo ao abrir um pet."
   },
   "petProfile": {
     "title": "Perfil do Pet",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from "./contexts/AuthContext";
 import { ProtectedRoute } from "./components/ProtectedRoute/ProtectedRoute";
 import { PublicCardPage } from "./pages/PublicCard/PublicCardPage";
 import { VetLoginPage } from "./pages/VetLogin/VetLoginPage";
+import { VetRegisterPage } from "./pages/VetRegister/VetRegisterPage";
 import { VetDashboardPage } from "./pages/VetDashboard/VetDashboardPage";
 import { VetPetProfilePage } from "./pages/VetPetProfile/VetPetProfilePage";
 import { VetScanPage } from "./pages/VetScan/VetScanPage";
@@ -52,6 +53,7 @@ createRoot(document.getElementById("root")!).render(
         <Routes>
           <Route path="/card/:token" element={<PublicCardPage />} />
           <Route path="/vet/login" element={<VetLoginPage />} />
+          <Route path="/vet/register" element={<VetRegisterPage />} />
           <Route
             path="/vet/dashboard"
             element={

--- a/src/pages/VetDashboard/VetDashboardPage.css
+++ b/src/pages/VetDashboard/VetDashboardPage.css
@@ -436,3 +436,14 @@
     min-width: 44px;
   }
 }
+
+.vet-dashboard-crmv-aviso {
+  margin: 0 0 1.25rem;
+  padding: 0.875rem 1rem;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 12px;
+  color: #92400e;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}

--- a/src/pages/VetDashboard/VetDashboardPage.test.tsx
+++ b/src/pages/VetDashboard/VetDashboardPage.test.tsx
@@ -11,8 +11,11 @@ import type {
 const navigateMock = vi.fn();
 const logoutMock = vi.fn();
 
+const locationMock = { state: null as unknown };
+
 vi.mock("react-router-dom", () => ({
   useNavigate: () => navigateMock,
+  useLocation: () => locationMock,
 }));
 
 vi.mock("../../hooks/useAuth", () => ({
@@ -58,6 +61,7 @@ describe("VetDashboardPage", () => {
     navigateMock.mockReset();
     logoutMock.mockReset();
     fetchMock.mockReset();
+    locationMock.state = null;
   });
 
   it("lista os pets atendidos retornados pela API", async () => {
@@ -135,6 +139,27 @@ describe("VetDashboardPage", () => {
         expect.objectContaining({ search: "rex", page: 1 }),
       ),
     );
+  });
+
+  it("avisa quando o cadastro terminou sem verificar o CRMV", async () => {
+    locationMock.state = { crmvVerificado: false };
+    fetchMock.mockResolvedValue(page([rex]));
+    render(<VetDashboardPage />);
+
+    expect(
+      await screen.findByText(/Não conseguimos confirmar seu CRMV/),
+    ).toBeInTheDocument();
+  });
+
+  it("não avisa quando o CRMV saiu verificado", async () => {
+    locationMock.state = { crmvVerificado: true };
+    fetchMock.mockResolvedValue(page([rex]));
+    render(<VetDashboardPage />);
+    await screen.findByText("Rex");
+
+    expect(
+      screen.queryByText(/Não conseguimos confirmar seu CRMV/),
+    ).not.toBeInTheDocument();
   });
 
   it("desabilita os botões de paginação numa página única", async () => {

--- a/src/pages/VetDashboard/VetDashboardPage.tsx
+++ b/src/pages/VetDashboard/VetDashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   IoPaw,
@@ -32,6 +32,12 @@ export function VetDashboardPage() {
   const { t } = useTranslation();
   const { user, token, logout } = useAuth();
   const navigate = useNavigate();
+  // O cadastro (api#124) avisa aqui quando a consulta ao CFMV não liberou o
+  // acesso clínico, para o vet não descobrir só no primeiro atendimento.
+  const location = useLocation();
+  const crmvNaoVerificado =
+    (location.state as { crmvVerificado?: boolean } | null)?.crmvVerificado ===
+    false;
 
   const [data, setData] = useState<PaginatedResponse<DashboardPetItem> | null>(
     null,
@@ -113,6 +119,12 @@ export function VetDashboardPage() {
       </header>
 
       <main className="vet-dashboard-content">
+        {crmvNaoVerificado && (
+          <p className="vet-dashboard-crmv-aviso" role="status">
+            {t("vetDashboard.crmvNaoVerificado")}
+          </p>
+        )}
+
         <div className="vet-dashboard-title-row">
           <div>
             <h2>{t("vetDashboard.title")}</h2>

--- a/src/pages/VetLogin/VetLoginPage.css
+++ b/src/pages/VetLogin/VetLoginPage.css
@@ -128,3 +128,26 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+.vet-login-hint {
+  color: #607d8b;
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.vet-login-alt {
+  margin: 1.25rem 0 0;
+  text-align: center;
+  color: #607d8b;
+  font-size: 0.875rem;
+}
+
+.vet-login-alt a {
+  color: #27a9d8;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.vet-login-alt a:hover {
+  text-decoration: underline;
+}

--- a/src/pages/VetLogin/VetLoginPage.test.tsx
+++ b/src/pages/VetLogin/VetLoginPage.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../hooks/useAuth", () => ({
 
 vi.mock("react-router-dom", () => ({
   useNavigate: () => navigateMock,
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
 }));
 
 async function fillAndSubmit(email = "vet@petcard.com", password = "senha123") {

--- a/src/pages/VetLogin/VetLoginPage.tsx
+++ b/src/pages/VetLogin/VetLoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { FormEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { IoPaw } from "react-icons/io5";
 import { useAuth } from "../../hooks/useAuth";
@@ -87,6 +87,11 @@ export function VetLoginPage() {
             {submitting ? t("vetLogin.submitting") : t("vetLogin.submit")}
           </button>
         </form>
+
+        <p className="vet-login-alt">
+          {t("vetLogin.noAccount")}{" "}
+          <Link to="/vet/register">{t("vetLogin.goToRegister")}</Link>
+        </p>
       </div>
     </div>
   );

--- a/src/pages/VetRegister/VetRegisterPage.test.tsx
+++ b/src/pages/VetRegister/VetRegisterPage.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VetRegisterPage } from "./VetRegisterPage";
+import { ApiError } from "../../services/api";
+
+const registerMock = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => ({ register: registerMock }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}));
+
+async function preencher(
+  overrides: { password?: string; confirm?: string } = {},
+) {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("Nome completo"), "Dra. Camila");
+  await user.type(screen.getByLabelText("CRMV"), "CRMV-SP 12345");
+  await user.type(screen.getByLabelText("E-mail"), "camila@vet.com");
+  await user.type(
+    screen.getByLabelText("Senha"),
+    overrides.password ?? "senha-forte",
+  );
+  await user.type(
+    screen.getByLabelText("Confirmar senha"),
+    overrides.confirm ?? overrides.password ?? "senha-forte",
+  );
+  await user.click(screen.getByRole("button", { name: "Criar conta" }));
+}
+
+describe("VetRegisterPage", () => {
+  beforeEach(() => {
+    registerMock.mockReset();
+    navigateMock.mockReset();
+  });
+
+  it("cadastra e navega para o dashboard", async () => {
+    registerMock.mockResolvedValue(true);
+    render(<VetRegisterPage />);
+
+    await preencher();
+
+    expect(registerMock).toHaveBeenCalledWith({
+      nome: "Dra. Camila",
+      email: "camila@vet.com",
+      crmv: "CRMV-SP 12345",
+      password: "senha-forte",
+      telefone: undefined,
+    });
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith("/vet/dashboard", {
+        replace: true,
+        state: { crmvVerificado: true },
+      }),
+    );
+  });
+
+  it("envia o telefone quando preenchido", async () => {
+    registerMock.mockResolvedValue(true);
+    render(<VetRegisterPage />);
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByLabelText("Telefone (opcional)"),
+      "11999990000",
+    );
+    await preencher();
+
+    expect(registerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ telefone: "11999990000" }),
+    );
+  });
+
+  it("entra mesmo sem o CRMV verificado — o aviso aparece na tela do pet", async () => {
+    registerMock.mockResolvedValue(false);
+    render(<VetRegisterPage />);
+
+    await preencher();
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith("/vet/dashboard", {
+        replace: true,
+        state: { crmvVerificado: false },
+      }),
+    );
+  });
+
+  it("barra senhas divergentes sem chamar a API", async () => {
+    render(<VetRegisterPage />);
+
+    await preencher({ password: "senha-forte", confirm: "outra-senha" });
+
+    expect(
+      await screen.findByText("As senhas não coincidem."),
+    ).toBeInTheDocument();
+    expect(registerMock).not.toHaveBeenCalled();
+  });
+
+  it("avisa sobre e-mail ou CRMV duplicado no 409", async () => {
+    registerMock.mockRejectedValue(new ApiError(409, "Conflict"));
+    render(<VetRegisterPage />);
+
+    await preencher();
+
+    expect(
+      await screen.findByText("Já existe uma conta com esse e-mail ou CRMV."),
+    ).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("mostra a mensagem da API no 400 de CRMV mal formatado", async () => {
+    registerMock.mockRejectedValue(
+      new ApiError(
+        400,
+        "Bad Request",
+        'CRMV "abc" não está num formato reconhecido.',
+      ),
+    );
+    render(<VetRegisterPage />);
+
+    await preencher();
+
+    expect(
+      await screen.findByText(/não está num formato reconhecido/),
+    ).toBeInTheDocument();
+  });
+
+  it("mostra erro genérico para falhas inesperadas", async () => {
+    registerMock.mockRejectedValue(new ApiError(500, "Internal Server Error"));
+    render(<VetRegisterPage />);
+
+    await preencher();
+
+    expect(
+      await screen.findByText("Erro ao criar a conta. Tente novamente."),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/VetRegister/VetRegisterPage.tsx
+++ b/src/pages/VetRegister/VetRegisterPage.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import type { FormEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { IoPaw } from "react-icons/io5";
+import { useAuth } from "../../hooks/useAuth";
+import { ApiError } from "../../services/api";
+import "../VetLogin/VetLoginPage.css";
+
+export function VetRegisterPage() {
+  const { t } = useTranslation();
+  const { register } = useAuth();
+  const navigate = useNavigate();
+
+  const [nome, setNome] = useState("");
+  const [email, setEmail] = useState("");
+  const [crmv, setCrmv] = useState("");
+  const [telefone, setTelefone] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmacao, setConfirmacao] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (password !== confirmacao) {
+      setError(t("vetRegister.passwordMismatch"));
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      const verificado = await register({
+        nome,
+        email,
+        crmv,
+        password,
+        telefone: telefone.trim() === "" ? undefined : telefone,
+      });
+      // Quem entra sem verificação vê o aviso com o botão de verificar na
+      // tela do pet (api#113), então o cadastro não precisa travar aqui.
+      navigate("/vet/dashboard", {
+        replace: true,
+        state: { crmvVerificado: verificado },
+      });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        setError(t("vetRegister.duplicate"));
+      } else if (err instanceof ApiError && err.status === 400) {
+        setError(err.detail ?? t("vetRegister.invalid"));
+      } else {
+        setError(t("vetRegister.genericError"));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="vet-login-page">
+      <div className="vet-login-card">
+        <div className="vet-login-logo">
+          <div className="vet-login-logo-mark">
+            <IoPaw size={24} color="#fff" />
+          </div>
+        </div>
+
+        <h1 className="vet-login-title">{t("brand.name")}</h1>
+        <p className="vet-login-subtitle">{t("vetRegister.subtitle")}</p>
+
+        <form className="vet-login-form" onSubmit={handleSubmit}>
+          <div className="vet-login-field">
+            <label htmlFor="nome">{t("vetRegister.nome")}</label>
+            <input
+              id="nome"
+              type="text"
+              value={nome}
+              onChange={(e) => setNome(e.target.value)}
+              placeholder={t("vetRegister.nomePlaceholder")}
+              required
+              minLength={2}
+              autoComplete="name"
+              disabled={submitting}
+            />
+          </div>
+
+          <div className="vet-login-field">
+            <label htmlFor="crmv">{t("vetRegister.crmv")}</label>
+            <input
+              id="crmv"
+              type="text"
+              value={crmv}
+              onChange={(e) => setCrmv(e.target.value)}
+              placeholder={t("vetRegister.crmvPlaceholder")}
+              required
+              disabled={submitting}
+            />
+            <small className="vet-login-hint">
+              {t("vetRegister.crmvHint")}
+            </small>
+          </div>
+
+          <div className="vet-login-field">
+            <label htmlFor="email">{t("vetRegister.email")}</label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder={t("vetRegister.emailPlaceholder")}
+              required
+              autoComplete="email"
+              disabled={submitting}
+            />
+          </div>
+
+          <div className="vet-login-field">
+            <label htmlFor="telefone">{t("vetRegister.telefone")}</label>
+            <input
+              id="telefone"
+              type="tel"
+              value={telefone}
+              onChange={(e) => setTelefone(e.target.value)}
+              placeholder={t("vetRegister.telefonePlaceholder")}
+              autoComplete="tel"
+              disabled={submitting}
+            />
+          </div>
+
+          <div className="vet-login-field">
+            <label htmlFor="password">{t("vetRegister.password")}</label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder={t("vetRegister.passwordPlaceholder")}
+              required
+              minLength={6}
+              autoComplete="new-password"
+              disabled={submitting}
+            />
+          </div>
+
+          <div className="vet-login-field">
+            <label htmlFor="confirmacao">{t("vetRegister.confirm")}</label>
+            <input
+              id="confirmacao"
+              type="password"
+              value={confirmacao}
+              onChange={(e) => setConfirmacao(e.target.value)}
+              placeholder={t("vetRegister.confirmPlaceholder")}
+              required
+              autoComplete="new-password"
+              disabled={submitting}
+            />
+          </div>
+
+          {error && <p className="vet-login-error">{error}</p>}
+
+          <button
+            type="submit"
+            className="vet-login-button"
+            disabled={submitting}
+          >
+            {submitting ? t("vetRegister.submitting") : t("vetRegister.submit")}
+          </button>
+        </form>
+
+        <p className="vet-login-alt">
+          {t("vetRegister.hasAccount")}{" "}
+          <Link to="/vet/login">{t("vetRegister.goToLogin")}</Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/services/auth.service.test.ts
+++ b/src/services/auth.service.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getVeterinarioProfile, loginVeterinario } from "./auth.service";
+import {
+  getVeterinarioProfile,
+  loginVeterinario,
+  registerVeterinario,
+} from "./auth.service";
 
 const BASE = "http://localhost:3000";
 
@@ -43,6 +47,36 @@ describe("auth.service", () => {
         }),
       }),
     );
+  });
+
+  it("registerVeterinario faz POST no endpoint público de cadastro", async () => {
+    const payload = {
+      access_token: "jwt",
+      user: { id: "v1", nome: "Dr. Carlos" },
+      crmv_verificado: true,
+    };
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: () => Promise.resolve(payload),
+    } as Response);
+
+    const res = await registerVeterinario({
+      nome: "Dr. Carlos",
+      email: "carlos@vet.com",
+      password: "senha-forte",
+      crmv: "CRMV-SP 12345",
+    });
+
+    expect(res.crmv_verificado).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE}/auth/veterinario/register`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    // O cadastro é público: nada de Authorization aqui.
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).headers).not.toHaveProperty("Authorization");
   });
 
   it("getVeterinarioProfile envia o token no header e usa GET", async () => {

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -19,10 +19,32 @@ export interface VetLoginResponse {
   user: VetUser;
 }
 
+export interface VetRegisterRequest {
+  nome: string;
+  email: string;
+  password: string;
+  crmv: string;
+  telefone?: string;
+}
+
+export interface VetRegisterResponse extends VetLoginResponse {
+  /** Se a consulta ao CFMV durante o cadastro já liberou o acesso clínico. */
+  crmv_verificado: boolean;
+}
+
 export function loginVeterinario(
   dto: VetLoginRequest,
 ): Promise<VetLoginResponse> {
   return apiFetch<VetLoginResponse>("/auth/veterinario/login", {
+    method: "POST",
+    body: dto,
+  });
+}
+
+export function registerVeterinario(
+  dto: VetRegisterRequest,
+): Promise<VetRegisterResponse> {
+  return apiFetch<VetRegisterResponse>("/auth/veterinario/register", {
     method: "POST",
     body: dto,
   });


### PR DESCRIPTION
Parte web da PetCardOrg/petcard-api#124. **Depende de PetCardOrg/petcard-api#125** — a rota `/auth/veterinario/register` só existe depois daquele merge.

## O que muda

- Nova tela **`/vet/register`**: nome, CRMV, e-mail, telefone (opcional), senha e confirmação. Reusa o visual da tela de login.
- **Links recíprocos**: "Criar conta" no login, "Entrar" no cadastro.
- `AuthContext.register` cadastra e já autentica, devolvendo se o CRMV saiu verificado.
- Quando a verificação não passa, o veterinário **entra assim mesmo** e o dashboard avisa. O bloqueio com o botão de verificar continua na tela do pet (api#113) — o cadastro não é lugar de trancar ninguém.

A confirmação de senha é validada no cliente antes de chamar a API; 409 e 400 têm mensagens próprias, e o 400 mostra a mensagem da API (que explica o formato de CRMV esperado).

## Verificação

- 72 testes verdes; cobertura **84.46 / 79.34 / 83.09 / 84.46** (catraca 80/75/78/80).
- Strings nos dois idiomas (pt-BR e en-US).
- `npm run lint` e `npm run build` limpos.
