### PR TITLE
feat: entrar direto após autenticar pelo QR e verificar CRMV no aviso

### DIFF
--- a/src/components/CrmvAviso/CrmvAviso.css
+++ b/src/components/CrmvAviso/CrmvAviso.css
@@ -1,0 +1,29 @@
+/* Aviso acionável de CRMV não verificado (api#113). O layout do bloco fica
+   com a tela que o usa; aqui só o que é comum aos três lugares. */
+.crmv-aviso-mensagem {
+  margin: 0 0 0.75rem;
+  line-height: 1.45;
+}
+
+.crmv-aviso-botao {
+  padding: 0.5rem 1rem;
+  border: 1px solid #d8eef6;
+  border-radius: 8px;
+  background: #fff;
+  color: #107fa8;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.crmv-aviso-botao:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.crmv-aviso-erro {
+  margin: 0.625rem 0 0;
+  color: #e63946;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}

--- a/src/components/CrmvAviso/CrmvAviso.test.tsx
+++ b/src/components/CrmvAviso/CrmvAviso.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CrmvAviso } from "./CrmvAviso";
+
+vi.mock("../../services/crmv.service", () => ({
+  verificarCrmv: vi.fn(),
+}));
+
+import { verificarCrmv } from "../../services/crmv.service";
+const verificarMock = vi.mocked(verificarCrmv);
+
+describe("CrmvAviso", () => {
+  const onVerificado = vi.fn();
+
+  beforeEach(() => {
+    verificarMock.mockReset();
+    onVerificado.mockReset();
+  });
+
+  async function clicarEmVerificar() {
+    await userEvent.click(
+      screen.getByRole("button", { name: "Verificar meu CRMV" }),
+    );
+  }
+
+  it("devolve o controle à tela quando o registro é aprovado", async () => {
+    verificarMock.mockResolvedValue({ verified: true });
+    render(
+      <CrmvAviso
+        token="jwt-vet"
+        mensagem="Acesso barrado"
+        onVerificado={onVerificado}
+      />,
+    );
+
+    await clicarEmVerificar();
+
+    // Sem este retorno o vet verifica o CRMV e continua olhando o bloqueio.
+    await waitFor(() => expect(onVerificado).toHaveBeenCalled());
+  });
+
+  it("mostra a situação do conselho quando o registro é recusado", async () => {
+    verificarMock.mockResolvedValue({ verified: false, situacao: "SUSPENSO" });
+    render(
+      <CrmvAviso
+        token="jwt-vet"
+        mensagem="Acesso barrado"
+        onVerificado={onVerificado}
+      />,
+    );
+
+    await clicarEmVerificar();
+
+    // A situação é o que diz ao vet se o problema é o cadastro ou o registro.
+    expect(await screen.findByText(/SUSPENSO/)).toBeInTheDocument();
+    expect(onVerificado).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/CrmvAviso/CrmvAviso.tsx
+++ b/src/components/CrmvAviso/CrmvAviso.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { verificarCrmv } from "../../services/crmv.service";
+import { ApiError } from "../../services/api";
+import "./CrmvAviso.css";
+
+interface CrmvAvisoProps {
+  token: string | null;
+  /** Por que o acesso está barrado — varia conforme a tela que avisa. */
+  mensagem: string;
+  /** Chamado quando a verificação passa: cada tela refaz o que ficou parado. */
+  onVerificado: () => void;
+  className?: string;
+}
+
+/**
+ * Aviso de CRMV não verificado com o botão que resolve o problema.
+ *
+ * Sem o botão o veterinário fica sem saída: o texto explica o bloqueio, mas
+ * a verificação é uma chamada que só a aplicação sabe disparar (api#113).
+ * Por isso o aviso é sempre acionável, em qualquer tela onde apareça.
+ */
+export function CrmvAviso({
+  token,
+  mensagem,
+  onVerificado,
+  className,
+}: CrmvAvisoProps) {
+  const { t } = useTranslation();
+  const [verificando, setVerificando] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  async function verificar() {
+    if (!token) return;
+    setVerificando(true);
+    setErro(null);
+    try {
+      const status = await verificarCrmv(token);
+      if (status.verified) {
+        onVerificado();
+        return;
+      }
+      // Recusa do conselho não é falha da chamada: dizer qual é a situação
+      // é o que permite ao vet corrigir o cadastro.
+      setErro(t("crmv.refused", { situacao: status.situacao ?? "-" }));
+    } catch (err) {
+      setErro(
+        err instanceof ApiError && err.detail ? err.detail : t("crmv.failed"),
+      );
+    } finally {
+      setVerificando(false);
+    }
+  }
+
+  return (
+    <div
+      className={className ? `crmv-aviso ${className}` : "crmv-aviso"}
+      role="status"
+    >
+      <p className="crmv-aviso-mensagem">{mensagem}</p>
+      <button
+        type="button"
+        className="crmv-aviso-botao"
+        onClick={() => void verificar()}
+        disabled={verificando || !token}
+      >
+        {verificando ? t("crmv.verifying") : t("crmv.verify")}
+      </button>
+      {erro && <p className="crmv-aviso-erro">{erro}</p>}
+    </div>
+  );
+}

--- a/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -12,7 +12,7 @@ function renderWithAuth(auth: Partial<AuthContextValue>) {
     user: null,
     loading: false,
     login: async () => {},
-    register: async () => true,
+    register: async () => {},
     logout: () => {},
     ...auth,
   };

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -71,7 +71,7 @@ describe("AuthProvider / useAuth", () => {
     expect(result.current.user).toEqual(vetUser);
   });
 
-  it("register autentica direto e informa se o CRMV saiu verificado", async () => {
+  it("register já deixa o vet autenticado, mesmo sem o CRMV verificado", async () => {
     registerMock.mockResolvedValue({
       access_token: "jwt-novo",
       user: vetUser,
@@ -79,9 +79,8 @@ describe("AuthProvider / useAuth", () => {
     });
     const { result } = renderHook(() => useAuth(), { wrapper });
 
-    let verificado: boolean | undefined;
     await act(async () => {
-      verificado = await result.current.register({
+      await result.current.register({
         nome: "Dra. Camila",
         email: "vet@petcard.com",
         password: "senha123",
@@ -89,8 +88,8 @@ describe("AuthProvider / useAuth", () => {
       });
     });
 
-    // Sem verificação o vet ainda entra; o bloqueio aparece na tela do pet.
-    expect(verificado).toBe(false);
+    // Verificação pendente não barra a entrada: o aviso acionável aparece
+    // no destino (api#113).
     expect(localStorage.getItem(TOKEN_KEY)).toBe("jwt-novo");
     expect(result.current.user).toEqual(vetUser);
   });

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -58,7 +58,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       user: response.user,
       loading: false,
     });
-    return response.crmv_verificado;
   }, []);
 
   const logout = useCallback(() => {

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -9,8 +9,13 @@ interface AuthState {
 
 export interface AuthContextValue extends AuthState {
   login: (email: string, password: string) => Promise<void>;
-  /** Cadastra e já autentica. Devolve se o CRMV saiu verificado da consulta. */
-  register: (dto: VetRegisterRequest) => Promise<boolean>;
+  /**
+   * Cadastra e já autentica.
+   *
+   * A situação do CRMV não sai daqui: quem precisa dela consulta
+   * `GET /veterinarios/me/crmv`, que continua valendo depois do cadastro.
+   */
+  register: (dto: VetRegisterRequest) => Promise<void>;
   logout: () => void;
 }
 

--- a/src/i18n/locales/en-US/common.json
+++ b/src/i18n/locales/en-US/common.json
@@ -135,12 +135,20 @@
       "next": "Next",
       "page": "Page {{current}} of {{total}}"
     },
-    "crmvNaoVerificado": "We could not confirm your CRMV right now. You can use the system, but pets' clinical history only opens after verification — you can try again when opening a pet.",
     "remover": {
       "rotulo": "Remove {{nome}} from the list",
       "confirmar": "Remove {{nome}} from your list? The pet clinical history is kept, and scanning the QR Code again brings it back.",
       "erro": "Could not remove the pet from the list. Please try again."
     }
+  },
+  "crmv": {
+    "title": "CRMV not verified",
+    "blocked": "Your CRMV must be verified to access clinical data.",
+    "verify": "Verify my CRMV",
+    "verifying": "Verifying...",
+    "refused": "The registration was not accepted (status: {{situacao}}). Check the CRMV in your profile.",
+    "failed": "Could not verify your CRMV right now. Please try again.",
+    "pending": "We could not confirm your CRMV. You can already use the system, but pets' clinical history only opens after verification."
   },
   "petProfile": {
     "title": "Pet Profile",
@@ -182,14 +190,6 @@
       "cancel": "Cancel",
       "submitError": "Failed to save clinical note. Please try again.",
       "editTitle": "Edit clinical note"
-    },
-    "crmv": {
-      "title": "CRMV not verified",
-      "blocked": "Your CRMV must be verified to access clinical data.",
-      "verify": "Verify my CRMV",
-      "verifying": "Verifying...",
-      "refused": "The registration was not accepted (status: {{situacao}}). Check the CRMV in your profile.",
-      "failed": "Could not verify your CRMV right now. Please try again."
     },
     "recordForm": {
       "title": {

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -135,12 +135,20 @@
       "next": "Próxima",
       "page": "Página {{current}} de {{total}}"
     },
-    "crmvNaoVerificado": "Não conseguimos confirmar seu CRMV agora. Você já pode usar o sistema, mas o histórico clínico dos pets só abre depois da verificação — é possível tentar de novo ao abrir um pet.",
     "remover": {
       "rotulo": "Tirar {{nome}} da lista",
       "confirmar": "Tirar {{nome}} da sua lista? O histórico clínico do pet continua guardado, e ler o QR Code de novo traz ele de volta.",
       "erro": "Não foi possível tirar o pet da lista. Tente de novo."
     }
+  },
+  "crmv": {
+    "title": "CRMV não verificado",
+    "blocked": "Seu CRMV precisa estar verificado para acessar dados clínicos.",
+    "verify": "Verificar meu CRMV",
+    "verifying": "Verificando...",
+    "refused": "O registro não foi aceito (situação: {{situacao}}). Confira o CRMV no seu cadastro.",
+    "failed": "Não foi possível verificar seu CRMV agora. Tente novamente.",
+    "pending": "Não conseguimos confirmar seu CRMV. Você já pode usar o sistema, mas o histórico clínico dos pets só abre depois da verificação."
   },
   "petProfile": {
     "title": "Perfil do Pet",
@@ -182,14 +190,6 @@
       "cancel": "Cancelar",
       "submitError": "Erro ao salvar a nota clínica. Tente novamente.",
       "editTitle": "Editar Nota Clínica"
-    },
-    "crmv": {
-      "title": "CRMV não verificado",
-      "blocked": "Seu CRMV precisa estar verificado para acessar dados clínicos.",
-      "verify": "Verificar meu CRMV",
-      "verifying": "Verificando...",
-      "refused": "O registro não foi aceito (situação: {{situacao}}). Confira o CRMV no seu cadastro.",
-      "failed": "Não foi possível verificar seu CRMV agora. Tente novamente."
     },
     "recordForm": {
       "title": {

--- a/src/pages/PublicCard/PublicCardPage.css
+++ b/src/pages/PublicCard/PublicCardPage.css
@@ -466,3 +466,12 @@ tbody tr:hover {
   color: #c0392b;
   font-size: 0.875rem;
 }
+
+/* CRMV pendente (api#113): ocupa a linha inteira do bloco, abaixo do botão. */
+.vet-access-crmv {
+  flex: 1 0 100%;
+  padding-top: 0.75rem;
+  border-top: 1px solid #cbe8f4;
+  color: #34606f;
+  font-size: 0.875rem;
+}

--- a/src/pages/PublicCard/PublicCardPage.test.tsx
+++ b/src/pages/PublicCard/PublicCardPage.test.tsx
@@ -28,6 +28,10 @@ vi.mock("../../services/dashboard.service", () => ({
   adicionarPetAtendido: vi.fn(),
 }));
 
+vi.mock("../../services/crmv.service", () => ({
+  verificarCrmv: vi.fn(),
+}));
+
 import { getPublicCard } from "../../services/card.service";
 import { adicionarPetAtendido } from "../../services/dashboard.service";
 const cardMock = vi.mocked(getPublicCard);
@@ -130,9 +134,11 @@ describe("PublicCardPage", () => {
     expect(navigateMock).toHaveBeenCalledWith("/vet/pets/p1");
   });
 
-  it("explica o bloqueio quando o CRMV não está verificado", async () => {
+  it("oferece a verificação quando o CRMV barra o acesso", async () => {
     authToken = "jwt-vet";
-    adicionarMock.mockRejectedValue(new ApiError(403, "Forbidden"));
+    adicionarMock.mockRejectedValue(
+      new ApiError(403, "Forbidden", "CRMV não verificado"),
+    );
     cardMock.mockResolvedValue(buildCard() as never);
     render(<PublicCardPage />);
     await screen.findByText("Rex");
@@ -145,6 +151,11 @@ describe("PublicCardPage", () => {
       await screen.findByText(
         "Seu CRMV precisa estar verificado para acessar dados clínicos.",
       ),
+    ).toBeInTheDocument();
+    // O vet chegou aqui com o pet na frente: mandá-lo procurar a verificação
+    // em outra tela é perder o atendimento.
+    expect(
+      screen.getByRole("button", { name: "Verificar meu CRMV" }),
     ).toBeInTheDocument();
     expect(navigateMock).not.toHaveBeenCalled();
   });

--- a/src/pages/PublicCard/PublicCardPage.tsx
+++ b/src/pages/PublicCard/PublicCardPage.tsx
@@ -20,7 +20,9 @@ import { getPublicCard } from "../../services/card.service";
 import { adicionarPetAtendido } from "../../services/dashboard.service";
 import { ApiError } from "../../services/api";
 import { LanguageSwitcher } from "../../components/LanguageSwitcher/LanguageSwitcher";
+import { CrmvAviso } from "../../components/CrmvAviso/CrmvAviso";
 import { useAuth } from "../../hooks/useAuth";
+import { lerRedirecionamentoVet } from "../vetAuthRedirect";
 import "./PublicCardPage.css";
 
 function formatDate(iso: string): string {
@@ -184,6 +186,7 @@ export function PublicCardPage() {
   const [error, setError] = useState<"not_found" | "network" | null>(null);
   const [entrando, setEntrando] = useState(false);
   const [erroAcesso, setErroAcesso] = useState<string | null>(null);
+  const [crmvBloqueado, setCrmvBloqueado] = useState(false);
 
   useEffect(() => {
     if (!token) {
@@ -238,24 +241,27 @@ export function PublicCardPage() {
 
     setEntrando(true);
     setErroAcesso(null);
+    setCrmvBloqueado(false);
     try {
       await adicionarPetAtendido(authToken, token);
       navigate(`/vet/pets/${card.pet_id}`);
     } catch (err) {
-      setErroAcesso(
-        err instanceof ApiError && err.status === 403
-          ? t("publicCard.vetAccess.crmvRequired")
-          : t("publicCard.vetAccess.failed"),
-      );
+      // CRMV pendente não é falha: é um passo que falta, e o vet resolve
+      // sem sair da tela.
+      if (err instanceof ApiError && err.isCrmvNaoVerificado) {
+        setCrmvBloqueado(true);
+        return;
+      }
+      setErroAcesso(t("publicCard.vetAccess.failed"));
     } finally {
       setEntrando(false);
     }
   }, [authToken, card, navigate, t, token]);
 
-  // Quem chegou aqui vindo do login já pediu para entrar como veterinário;
-  // repetir o clique seria só atrito.
+  // Quem chegou aqui vindo do login ou do cadastro já pediu para entrar como
+  // veterinário; repetir o clique seria só atrito.
   const pediuAcessoVet = Boolean(
-    (location.state as { acessoVet?: boolean } | null)?.acessoVet,
+    lerRedirecionamentoVet(location.state).acessoVet,
   );
   useEffect(() => {
     if (pediuAcessoVet && authToken && card) {
@@ -382,6 +388,14 @@ export function PublicCardPage() {
               : t("publicCard.vetAccess.action")}
           </button>
           {erroAcesso && <p className="vet-access-error">{erroAcesso}</p>}
+          {crmvBloqueado && (
+            <CrmvAviso
+              token={authToken}
+              mensagem={t("publicCard.vetAccess.crmvRequired")}
+              onVerificado={() => void entrarComoVet()}
+              className="vet-access-crmv"
+            />
+          )}
         </section>
 
         {/* O QR fica só no app do tutor (web#34). Exibi-lo aqui não servia a

--- a/src/pages/VetDashboard/VetDashboardPage.css
+++ b/src/pages/VetDashboard/VetDashboardPage.css
@@ -448,6 +448,11 @@
   line-height: 1.45;
 }
 
+.vet-dashboard-crmv-aviso .crmv-aviso-botao {
+  border-color: #fcd34d;
+  color: #92400e;
+}
+
 .vet-pet-card-remove {
   display: flex;
   align-items: center;

--- a/src/pages/VetDashboard/VetDashboardPage.test.tsx
+++ b/src/pages/VetDashboard/VetDashboardPage.test.tsx
@@ -11,11 +11,8 @@ import type {
 const navigateMock = vi.fn();
 const logoutMock = vi.fn();
 
-const locationMock = { state: null as unknown };
-
 vi.mock("react-router-dom", () => ({
   useNavigate: () => navigateMock,
-  useLocation: () => locationMock,
 }));
 
 vi.mock("../../hooks/useAuth", () => ({
@@ -31,12 +28,19 @@ vi.mock("../../services/dashboard.service", () => ({
   removerPetAtendido: vi.fn(),
 }));
 
+vi.mock("../../services/crmv.service", () => ({
+  fetchCrmvStatus: vi.fn(),
+  verificarCrmv: vi.fn(),
+}));
+
 import {
   fetchDashboardPets,
   removerPetAtendido,
 } from "../../services/dashboard.service";
+import { fetchCrmvStatus } from "../../services/crmv.service";
 const fetchMock = vi.mocked(fetchDashboardPets);
 const removerMock = vi.mocked(removerPetAtendido);
+const crmvStatusMock = vi.mocked(fetchCrmvStatus);
 
 function page(
   items: DashboardPetItem[],
@@ -70,7 +74,9 @@ describe("VetDashboardPage", () => {
     fetchMock.mockReset();
     removerMock.mockReset();
     removerMock.mockResolvedValue(undefined);
-    locationMock.state = null;
+    // Padrão do resto da suíte: CRMV em dia, sem aviso na tela.
+    crmvStatusMock.mockReset();
+    crmvStatusMock.mockResolvedValue({ verified: true });
     confirmado = true;
     vi.spyOn(window, "confirm").mockImplementation(() => confirmado);
   });
@@ -146,18 +152,23 @@ describe("VetDashboardPage", () => {
     );
   });
 
-  it("avisa quando o cadastro terminou sem verificar o CRMV", async () => {
-    locationMock.state = { crmvVerificado: false };
+  it("avisa e oferece a verificação quando o CRMV está pendente", async () => {
+    // Sem o botão o vet leria o aviso e não teria o que fazer com ele: é a
+    // primeira tela dele, e o histórico clínico fica barrado até verificar.
+    crmvStatusMock.mockResolvedValue({ verified: false });
     fetchMock.mockResolvedValue(page([rex]));
     render(<VetDashboardPage />);
 
     expect(
       await screen.findByText(/Não conseguimos confirmar seu CRMV/),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Verificar meu CRMV" }),
+    ).toBeInTheDocument();
   });
 
-  it("não avisa quando o CRMV saiu verificado", async () => {
-    locationMock.state = { crmvVerificado: true };
+  it("não avisa quando o CRMV está verificado", async () => {
+    crmvStatusMock.mockResolvedValue({ verified: true });
     fetchMock.mockResolvedValue(page([rex]));
     render(<VetDashboardPage />);
     await screen.findByText("Rex");

--- a/src/pages/VetDashboard/VetDashboardPage.tsx
+++ b/src/pages/VetDashboard/VetDashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   IoPaw,
@@ -10,6 +10,7 @@ import {
 } from "react-icons/io5";
 import { useAuth } from "../../hooks/useAuth";
 import { LanguageSwitcher } from "../../components/LanguageSwitcher/LanguageSwitcher";
+import { CrmvAviso } from "../../components/CrmvAviso/CrmvAviso";
 import {
   fetchDashboardPets,
   removerPetAtendido,
@@ -18,6 +19,7 @@ import type {
   DashboardPetItem,
   PaginatedResponse,
 } from "../../services/dashboard.service";
+import { fetchCrmvStatus } from "../../services/crmv.service";
 import { ApiError } from "../../services/api";
 import "./VetDashboardPage.css";
 
@@ -35,12 +37,9 @@ export function VetDashboardPage() {
   const { t } = useTranslation();
   const { user, token, logout } = useAuth();
   const navigate = useNavigate();
-  // O cadastro (api#124) avisa aqui quando a consulta ao CFMV não liberou o
-  // acesso clínico, para o vet não descobrir só no primeiro atendimento.
-  const location = useLocation();
-  const crmvNaoVerificado =
-    (location.state as { crmvVerificado?: boolean } | null)?.crmvVerificado ===
-    false;
+  // O dashboard é a primeira tela do vet: é aqui que ele precisa descobrir
+  // que o CRMV não passou, e não no primeiro atendimento (api#113).
+  const [crmvVerificado, setCrmvVerificado] = useState<boolean | null>(null);
 
   const [data, setData] = useState<PaginatedResponse<DashboardPetItem> | null>(
     null,
@@ -77,6 +76,21 @@ export function VetDashboardPage() {
     },
     [token, logout],
   );
+
+  const carregarStatusCrmv = useCallback(async () => {
+    if (!token) return;
+    try {
+      const status = await fetchCrmvStatus(token);
+      setCrmvVerificado(status.verified);
+    } catch {
+      // O aviso é secundário: falhar a consulta não pode esconder a lista.
+      setCrmvVerificado(null);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void carregarStatusCrmv();
+  }, [carregarStatusCrmv]);
 
   useEffect(() => {
     load(search, page);
@@ -153,10 +167,13 @@ export function VetDashboardPage() {
       </header>
 
       <main className="vet-dashboard-content">
-        {crmvNaoVerificado && (
-          <p className="vet-dashboard-crmv-aviso" role="status">
-            {t("vetDashboard.crmvNaoVerificado")}
-          </p>
+        {crmvVerificado === false && (
+          <CrmvAviso
+            token={token}
+            mensagem={t("crmv.pending")}
+            onVerificado={() => void carregarStatusCrmv()}
+            className="vet-dashboard-crmv-aviso"
+          />
         )}
 
         <div className="vet-dashboard-title-row">

--- a/src/pages/VetLogin/VetLoginPage.test.tsx
+++ b/src/pages/VetLogin/VetLoginPage.test.tsx
@@ -43,20 +43,24 @@ describe("VetLoginPage", () => {
     await waitFor(() =>
       expect(navigateMock).toHaveBeenCalledWith("/vet/dashboard", {
         replace: true,
+        state: undefined,
       }),
     );
   });
 
-  it("volta para o pet quando o login veio da carteira do QR", async () => {
-    locationMock.state = { redirectTo: "/vet/pets/p1" };
+  it("volta para a carteira do QR mantendo o acesso de veterinário pedido", async () => {
+    // Perder `acessoVet` aqui não quebra nada visivelmente: a carteira só
+    // deixa de entrar sozinha e obriga um segundo clique em "Sou veterinário".
+    locationMock.state = { redirectTo: "/card/tok-123", acessoVet: true };
     loginMock.mockResolvedValue(undefined);
     render(<VetLoginPage />);
 
     await fillAndSubmit();
 
     await waitFor(() =>
-      expect(navigateMock).toHaveBeenCalledWith("/vet/pets/p1", {
+      expect(navigateMock).toHaveBeenCalledWith("/card/tok-123", {
         replace: true,
+        state: { acessoVet: true },
       }),
     );
   });

--- a/src/pages/VetLogin/VetLoginPage.tsx
+++ b/src/pages/VetLogin/VetLoginPage.tsx
@@ -5,17 +5,18 @@ import { useTranslation } from "react-i18next";
 import { IoPaw } from "react-icons/io5";
 import { useAuth } from "../../hooks/useAuth";
 import { ApiError } from "../../services/api";
+import { lerRedirecionamentoVet } from "../vetAuthRedirect";
 import "./VetLoginPage.css";
 
 export function VetLoginPage() {
   const { t } = useTranslation();
   const { login } = useAuth();
   const navigate = useNavigate();
-  // Quem chegou pela carteira do QR volta para o pet que escaneou.
+  // Quem chegou pela carteira do QR volta para ela já autenticado.
   const location = useLocation();
-  const redirectTo =
-    (location.state as { redirectTo?: string } | null)?.redirectTo ??
-    "/vet/dashboard";
+  const { redirectTo = "/vet/dashboard", acessoVet } = lerRedirecionamentoVet(
+    location.state,
+  );
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -29,7 +30,12 @@ export function VetLoginPage() {
 
     try {
       await login(email, password);
-      navigate(redirectTo, { replace: true });
+      // `acessoVet` precisa atravessar o login: é ele que diz à carteira que
+      // o clique em "Sou veterinário" já aconteceu.
+      navigate(redirectTo, {
+        replace: true,
+        state: acessoVet ? { acessoVet: true } : undefined,
+      });
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
         setError(t("vetLogin.invalidCredentials"));
@@ -95,7 +101,9 @@ export function VetLoginPage() {
 
         <p className="vet-login-alt">
           {t("vetLogin.noAccount")}{" "}
-          <Link to="/vet/register">{t("vetLogin.goToRegister")}</Link>
+          <Link to="/vet/register" state={location.state}>
+            {t("vetLogin.goToRegister")}
+          </Link>
         </p>
       </div>
     </div>

--- a/src/pages/VetPetProfile/VetPetProfilePage.css
+++ b/src/pages/VetPetProfile/VetPetProfilePage.css
@@ -645,7 +645,7 @@
 }
 
 /* Bloqueio por CRMV não verificado (api#113) */
-.vet-crmv-message {
+.vet-pet-profile-state-card .crmv-aviso-mensagem {
   color: var(--color-muted, #6b7c85);
   margin: 0 0 16px;
   max-width: 42ch;

--- a/src/pages/VetPetProfile/VetPetProfilePage.tsx
+++ b/src/pages/VetPetProfile/VetPetProfilePage.tsx
@@ -37,7 +37,7 @@ import {
   type HealthRecordForm,
   type HealthRecordType,
 } from "./healthRecordValidation";
-import { verificarCrmv } from "../../services/crmv.service";
+import { CrmvAviso } from "../../components/CrmvAviso/CrmvAviso";
 import { ApiError } from "../../services/api";
 import "./VetPetProfilePage.css";
 
@@ -118,8 +118,6 @@ export function VetPetProfilePage() {
   const [error, setError] = useState(false);
   // Bloqueio por CRMV não verificado (api#113): erro acionável, não falha genérica.
   const [crmvBloqueado, setCrmvBloqueado] = useState<string | null>(null);
-  const [verificandoCrmv, setVerificandoCrmv] = useState(false);
-  const [erroVerificacao, setErroVerificacao] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<
     "timeline" | "vaccines" | "dewormings" | "medications" | "notes"
   >("timeline");
@@ -165,7 +163,7 @@ export function VetPetProfilePage() {
         return;
       }
       if (err instanceof ApiError && err.isCrmvNaoVerificado) {
-        setCrmvBloqueado(err.detail ?? t("petProfile.crmv.blocked"));
+        setCrmvBloqueado(err.detail ?? t("crmv.blocked"));
         return;
       }
       setError(true);
@@ -173,32 +171,6 @@ export function VetPetProfilePage() {
       setLoading(false);
     }
   }, [token, id, logout, t]);
-
-  const handleVerificarCrmv = useCallback(async () => {
-    if (!token) return;
-    setVerificandoCrmv(true);
-    setErroVerificacao(null);
-    try {
-      const status = await verificarCrmv(token);
-      if (status.verified) {
-        await load();
-      } else {
-        setErroVerificacao(
-          t("petProfile.crmv.refused", {
-            situacao: status.situacao ?? "-",
-          }),
-        );
-      }
-    } catch (err) {
-      setErroVerificacao(
-        err instanceof ApiError && err.detail
-          ? err.detail
-          : t("petProfile.crmv.failed"),
-      );
-    } finally {
-      setVerificandoCrmv(false);
-    }
-  }, [token, load, t]);
 
   useEffect(() => {
     load();
@@ -513,20 +485,12 @@ export function VetPetProfilePage() {
             <div className="vet-pet-profile-state-icon vet-pet-profile-error-icon">
               <IoAlertCircle size={36} color="#e63946" />
             </div>
-            <h3>{t("petProfile.crmv.title")}</h3>
-            <p className="vet-crmv-message">{crmvBloqueado}</p>
-            <button
-              type="button"
-              onClick={handleVerificarCrmv}
-              disabled={verificandoCrmv}
-            >
-              {verificandoCrmv
-                ? t("petProfile.crmv.verifying")
-                : t("petProfile.crmv.verify")}
-            </button>
-            {erroVerificacao && (
-              <p className="vet-note-form-error">{erroVerificacao}</p>
-            )}
+            <h3>{t("crmv.title")}</h3>
+            <CrmvAviso
+              token={token}
+              mensagem={crmvBloqueado}
+              onVerificado={() => void load()}
+            />
           </div>
         )}
 

--- a/src/pages/VetRegister/VetRegisterPage.test.tsx
+++ b/src/pages/VetRegister/VetRegisterPage.test.tsx
@@ -11,8 +11,11 @@ vi.mock("../../hooks/useAuth", () => ({
   useAuth: () => ({ register: registerMock }),
 }));
 
+const locationMock = { state: null as unknown };
+
 vi.mock("react-router-dom", () => ({
   useNavigate: () => navigateMock,
+  useLocation: () => locationMock,
   Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
 }));
 
@@ -38,10 +41,11 @@ describe("VetRegisterPage", () => {
   beforeEach(() => {
     registerMock.mockReset();
     navigateMock.mockReset();
+    locationMock.state = null;
   });
 
   it("cadastra e navega para o dashboard", async () => {
-    registerMock.mockResolvedValue(true);
+    registerMock.mockResolvedValue(undefined);
     render(<VetRegisterPage />);
 
     await preencher();
@@ -56,13 +60,13 @@ describe("VetRegisterPage", () => {
     await waitFor(() =>
       expect(navigateMock).toHaveBeenCalledWith("/vet/dashboard", {
         replace: true,
-        state: { crmvVerificado: true },
+        state: undefined,
       }),
     );
   });
 
   it("envia o telefone quando preenchido", async () => {
-    registerMock.mockResolvedValue(true);
+    registerMock.mockResolvedValue(undefined);
     render(<VetRegisterPage />);
 
     const user = userEvent.setup();
@@ -77,16 +81,19 @@ describe("VetRegisterPage", () => {
     );
   });
 
-  it("entra mesmo sem o CRMV verificado — o aviso aparece na tela do pet", async () => {
-    registerMock.mockResolvedValue(false);
+  it("devolve para a carteira do QR quando o cadastro veio de lá", async () => {
+    // Sem carregar o redirecionamento, o vet cadastrado cairia no dashboard e
+    // teria de escanear o QR de novo para abrir o pet que já tinha na mão.
+    locationMock.state = { redirectTo: "/card/tok-123", acessoVet: true };
+    registerMock.mockResolvedValue(undefined);
     render(<VetRegisterPage />);
 
     await preencher();
 
     await waitFor(() =>
-      expect(navigateMock).toHaveBeenCalledWith("/vet/dashboard", {
+      expect(navigateMock).toHaveBeenCalledWith("/card/tok-123", {
         replace: true,
-        state: { crmvVerificado: false },
+        state: { acessoVet: true },
       }),
     );
   });

--- a/src/pages/VetRegister/VetRegisterPage.tsx
+++ b/src/pages/VetRegister/VetRegisterPage.tsx
@@ -1,16 +1,23 @@
 import { useState } from "react";
 import type { FormEvent } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { IoPaw } from "react-icons/io5";
 import { useAuth } from "../../hooks/useAuth";
 import { ApiError } from "../../services/api";
+import { lerRedirecionamentoVet } from "../vetAuthRedirect";
 import "../VetLogin/VetLoginPage.css";
 
 export function VetRegisterPage() {
   const { t } = useTranslation();
   const { register } = useAuth();
   const navigate = useNavigate();
+  // Quem veio da carteira do QR chegou aqui pelo link do login: o cadastro
+  // devolve o vet para o pet que ele escaneou, não para o dashboard.
+  const location = useLocation();
+  const { redirectTo = "/vet/dashboard", acessoVet } = lerRedirecionamentoVet(
+    location.state,
+  );
 
   const [nome, setNome] = useState("");
   const [email, setEmail] = useState("");
@@ -33,18 +40,18 @@ export function VetRegisterPage() {
     setSubmitting(true);
 
     try {
-      const verificado = await register({
+      await register({
         nome,
         email,
         crmv,
         password,
         telefone: telefone.trim() === "" ? undefined : telefone,
       });
-      // Quem entra sem verificação vê o aviso com o botão de verificar na
-      // tela do pet (api#113), então o cadastro não precisa travar aqui.
-      navigate("/vet/dashboard", {
+      // Quem entra sem verificação vê o aviso com o botão de verificar já no
+      // destino (api#113), então o cadastro não precisa travar aqui.
+      navigate(redirectTo, {
         replace: true,
-        state: { crmvVerificado: verificado },
+        state: acessoVet ? { acessoVet: true } : undefined,
       });
     } catch (err) {
       if (err instanceof ApiError && err.status === 409) {
@@ -172,7 +179,9 @@ export function VetRegisterPage() {
 
         <p className="vet-login-alt">
           {t("vetRegister.hasAccount")}{" "}
-          <Link to="/vet/login">{t("vetRegister.goToLogin")}</Link>
+          <Link to="/vet/login" state={location.state}>
+            {t("vetRegister.goToLogin")}
+          </Link>
         </p>
       </div>
     </div>

--- a/src/pages/vetAuthRedirect.ts
+++ b/src/pages/vetAuthRedirect.ts
@@ -1,0 +1,15 @@
+/**
+ * Estado que o veterinário carrega ao ser mandado para o login ou o cadastro.
+ *
+ * `acessoVet` é o que faz a carteira pública retomar sozinha o acesso depois
+ * de autenticar. Perder essa marca no caminho não quebra nada visivelmente —
+ * só obriga o vet a clicar em "Sou veterinário" uma segunda vez.
+ */
+export interface VetAuthRedirectState {
+  redirectTo?: string;
+  acessoVet?: boolean;
+}
+
+export function lerRedirecionamentoVet(state: unknown): VetAuthRedirectState {
+  return (state as VetAuthRedirectState | null) ?? {};
+}


### PR DESCRIPTION
## Problema

**1. Segundo clique em "Sou veterinário".** Quem clicava na carteira pública era mandado para o login com `{ redirectTo, acessoVet }`, mas o login navegava de volta **sem repassar o estado** — a carteira não sabia que o acesso já tinha sido pedido e esperava um novo clique. O cadastro era pior: não lia o redirecionamento, então quem criava conta a partir da carteira caía no dashboard e precisava escanear o QR de novo.

**2. Aviso de CRMV sem saída.** O botão "Verificar meu CRMV" só existia na tela do pet. No dashboard o aviso era um parágrafo solto — e vinha do estado de navegação do cadastro, então sumia ao recarregar e nunca aparecia para quem entrou por login. Na carteira pública, o 403 virava texto de erro.

## Mudanças

- `vetAuthRedirect.ts`: o estado (`redirectTo`, `acessoVet`) que atravessa login e cadastro. Os links entre as duas telas repassam.
- `CrmvAviso`: aviso acionável reutilizado nos três lugares — dashboard, carteira pública e prontuário.
- Dashboard: o aviso passa a vir de `GET /veterinarios/me/crmv`, não do estado de navegação.
- `AuthContext.register` deixa de devolver `crmv_verificado` — quem precisa da situação consulta a API, que é a fonte única.

## Testes

103 passando; cobertura 85,8 / 82,4 / 74,1 / 85,8, acima da catraca (84/80/73/84).

Três casos novos, todos ligados a regra de negócio (ADR-006): login preserva `acessoVet`, cadastro devolve à carteira do QR, e o `CrmvAviso` destrava a tela quando o registro é aprovado / mostra a situação quando é recusado. O teste do login foi conferido revertendo a correção — falha sem ela.

Sem mudança na API.