### PR TITLE
feat: corrigir o CRMV no próprio aviso de bloqueio

### DIFF
--- a/src/components/CrmvAviso/CrmvAviso.css
+++ b/src/components/CrmvAviso/CrmvAviso.css
@@ -5,6 +5,13 @@
   line-height: 1.45;
 }
 
+.crmv-aviso-acoes {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .crmv-aviso-botao {
   padding: 0.5rem 1rem;
   border: 1px solid #d8eef6;
@@ -16,9 +23,59 @@
   cursor: pointer;
 }
 
-.crmv-aviso-botao:disabled {
+.crmv-aviso-botao:disabled,
+.crmv-aviso-secundario:disabled {
   opacity: 0.6;
   cursor: default;
+}
+
+.crmv-aviso-secundario {
+  padding: 0.5rem 0.25rem;
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+/* Correção do CRMV: o veterinário arruma o registro onde o bloqueio apareceu,
+   sem precisar de uma tela de perfil que não existe. */
+.crmv-aviso-form {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.375rem;
+  max-width: 22rem;
+}
+
+.crmv-aviso-form label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.crmv-aviso-form input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #cbe8f4;
+  border-radius: 8px;
+  background: #fff;
+  color: inherit;
+  font-size: 0.9375rem;
+}
+
+.crmv-aviso-form input:disabled {
+  opacity: 0.6;
+}
+
+.crmv-aviso-dica {
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+.crmv-aviso-form .crmv-aviso-acoes {
+  margin-top: 0.25rem;
 }
 
 .crmv-aviso-erro {

--- a/src/components/CrmvAviso/CrmvAviso.test.tsx
+++ b/src/components/CrmvAviso/CrmvAviso.test.tsx
@@ -5,18 +5,45 @@ import { CrmvAviso } from "./CrmvAviso";
 
 vi.mock("../../services/crmv.service", () => ({
   verificarCrmv: vi.fn(),
+  corrigirMeuCrmv: vi.fn(),
 }));
 
-import { verificarCrmv } from "../../services/crmv.service";
+import { corrigirMeuCrmv, verificarCrmv } from "../../services/crmv.service";
 const verificarMock = vi.mocked(verificarCrmv);
+const corrigirMock = vi.mocked(corrigirMeuCrmv);
 
 describe("CrmvAviso", () => {
   const onVerificado = vi.fn();
 
   beforeEach(() => {
     verificarMock.mockReset();
+    corrigirMock.mockReset();
+    corrigirMock.mockResolvedValue(undefined);
     onVerificado.mockReset();
   });
+
+  function renderizar(crmvAtual?: string) {
+    render(
+      <CrmvAviso
+        token="jwt-vet"
+        mensagem="Acesso barrado"
+        crmvAtual={crmvAtual}
+        onVerificado={onVerificado}
+      />,
+    );
+  }
+
+  async function corrigirPara(novo: string) {
+    await userEvent.click(
+      screen.getByRole("button", { name: "Corrigir meu CRMV" }),
+    );
+    const campo = screen.getByLabelText("CRMV");
+    await userEvent.clear(campo);
+    await userEvent.type(campo, novo);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Salvar e verificar" }),
+    );
+  }
 
   async function clicarEmVerificar() {
     await userEvent.click(
@@ -26,13 +53,7 @@ describe("CrmvAviso", () => {
 
   it("devolve o controle à tela quando o registro é aprovado", async () => {
     verificarMock.mockResolvedValue({ verified: true });
-    render(
-      <CrmvAviso
-        token="jwt-vet"
-        mensagem="Acesso barrado"
-        onVerificado={onVerificado}
-      />,
-    );
+    renderizar();
 
     await clicarEmVerificar();
 
@@ -42,18 +63,37 @@ describe("CrmvAviso", () => {
 
   it("mostra a situação do conselho quando o registro é recusado", async () => {
     verificarMock.mockResolvedValue({ verified: false, situacao: "SUSPENSO" });
-    render(
-      <CrmvAviso
-        token="jwt-vet"
-        mensagem="Acesso barrado"
-        onVerificado={onVerificado}
-      />,
-    );
+    renderizar();
 
     await clicarEmVerificar();
 
     // A situação é o que diz ao vet se o problema é o cadastro ou o registro.
     expect(await screen.findByText(/SUSPENSO/)).toBeInTheDocument();
+    expect(onVerificado).not.toHaveBeenCalled();
+  });
+
+  it("salva o CRMV corrigido e verifica na mesma ação", async () => {
+    verificarMock.mockResolvedValue({ verified: true });
+    renderizar("CRMV-SP 00000");
+
+    await corrigirPara("CRMV-SP 12345");
+
+    // Reconsultar o mesmo número errado nunca destravaria: quem se cadastrou
+    // com o CRMV trocado só sai daqui corrigindo.
+    expect(corrigirMock).toHaveBeenCalledWith("jwt-vet", "CRMV-SP 12345");
+    await waitFor(() => expect(onVerificado).toHaveBeenCalled());
+  });
+
+  it("não destrava quando o CRMV corrigido também é recusado", async () => {
+    verificarMock.mockResolvedValue({
+      verified: false,
+      situacao: "Não encontrado",
+    });
+    renderizar("CRMV-SP 00000");
+
+    await corrigirPara("CRMV-SP 11111");
+
+    expect(await screen.findByText(/Não encontrado/)).toBeInTheDocument();
     expect(onVerificado).not.toHaveBeenCalled();
   });
 });

--- a/src/components/CrmvAviso/CrmvAviso.tsx
+++ b/src/components/CrmvAviso/CrmvAviso.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
+import type { FormEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { verificarCrmv } from "../../services/crmv.service";
+import { corrigirMeuCrmv, verificarCrmv } from "../../services/crmv.service";
 import { ApiError } from "../../services/api";
 import "./CrmvAviso.css";
 
@@ -8,47 +9,82 @@ interface CrmvAvisoProps {
   token: string | null;
   /** Por que o acesso está barrado — varia conforme a tela que avisa. */
   mensagem: string;
+  /** CRMV atual da conta, para o veterinário corrigir a partir dele. */
+  crmvAtual?: string;
   /** Chamado quando a verificação passa: cada tela refaz o que ficou parado. */
   onVerificado: () => void;
   className?: string;
 }
 
+function detalheOu(err: unknown, padrao: string): string {
+  return err instanceof ApiError && err.detail ? err.detail : padrao;
+}
+
 /**
- * Aviso de CRMV não verificado com o botão que resolve o problema.
+ * Aviso de CRMV não verificado com as duas saídas possíveis.
  *
- * Sem o botão o veterinário fica sem saída: o texto explica o bloqueio, mas
- * a verificação é uma chamada que só a aplicação sabe disparar (api#113).
- * Por isso o aviso é sempre acionável, em qualquer tela onde apareça.
+ * Verificar resolve quem só ainda não foi conferido. Quem digitou o registro
+ * errado no cadastro precisa **corrigir** antes: reconsultar o mesmo número
+ * errado seria um beco sem saída, e não havia tela de perfil para arrumá-lo.
  */
 export function CrmvAviso({
   token,
   mensagem,
+  crmvAtual,
   onVerificado,
   className,
 }: CrmvAvisoProps) {
   const { t } = useTranslation();
   const [verificando, setVerificando] = useState(false);
+  const [salvando, setSalvando] = useState(false);
+  const [corrigindo, setCorrigindo] = useState(false);
+  const [crmv, setCrmv] = useState(crmvAtual ?? "");
   const [erro, setErro] = useState<string | null>(null);
+
+  /** Consulta o conselho e destrava a tela, ou explica a recusa. */
+  async function consultarConselho(autenticacao: string) {
+    const status = await verificarCrmv(autenticacao);
+    if (status.verified) {
+      onVerificado();
+      return;
+    }
+    // Recusa do conselho não é falha da chamada: dizer qual é a situação
+    // é o que permite ao vet corrigir o cadastro.
+    setErro(t("crmv.refused", { situacao: status.situacao ?? "-" }));
+  }
 
   async function verificar() {
     if (!token) return;
     setVerificando(true);
     setErro(null);
     try {
-      const status = await verificarCrmv(token);
-      if (status.verified) {
-        onVerificado();
-        return;
-      }
-      // Recusa do conselho não é falha da chamada: dizer qual é a situação
-      // é o que permite ao vet corrigir o cadastro.
-      setErro(t("crmv.refused", { situacao: status.situacao ?? "-" }));
+      await consultarConselho(token);
     } catch (err) {
-      setErro(
-        err instanceof ApiError && err.detail ? err.detail : t("crmv.failed"),
-      );
+      setErro(detalheOu(err, t("crmv.failed")));
     } finally {
       setVerificando(false);
+    }
+  }
+
+  async function salvarECorrigir(e: FormEvent) {
+    e.preventDefault();
+    if (!token) return;
+
+    setSalvando(true);
+    setErro(null);
+    try {
+      await corrigirMeuCrmv(token, crmv.trim());
+      // Salvar sem conferir não abriria nada: a troca zera a verificação na
+      // API, então as duas coisas são uma ação só para o veterinário.
+      await consultarConselho(token);
+    } catch (err) {
+      setErro(
+        err instanceof ApiError && err.status === 409
+          ? t("crmv.duplicate")
+          : detalheOu(err, t("crmv.saveFailed")),
+      );
+    } finally {
+      setSalvando(false);
     }
   }
 
@@ -58,14 +94,63 @@ export function CrmvAviso({
       role="status"
     >
       <p className="crmv-aviso-mensagem">{mensagem}</p>
-      <button
-        type="button"
-        className="crmv-aviso-botao"
-        onClick={() => void verificar()}
-        disabled={verificando || !token}
-      >
-        {verificando ? t("crmv.verifying") : t("crmv.verify")}
-      </button>
+
+      {corrigindo ? (
+        <form
+          className="crmv-aviso-form"
+          onSubmit={(e) => void salvarECorrigir(e)}
+        >
+          <label htmlFor="crmv-correcao">{t("crmv.fixLabel")}</label>
+          <input
+            id="crmv-correcao"
+            type="text"
+            value={crmv}
+            onChange={(e) => setCrmv(e.target.value)}
+            placeholder={t("crmv.fixPlaceholder")}
+            required
+            minLength={3}
+            disabled={salvando}
+          />
+          <small className="crmv-aviso-dica">{t("crmv.fixHint")}</small>
+          <div className="crmv-aviso-acoes">
+            <button
+              type="submit"
+              className="crmv-aviso-botao"
+              disabled={salvando || !token}
+            >
+              {salvando ? t("crmv.saving") : t("crmv.save")}
+            </button>
+            <button
+              type="button"
+              className="crmv-aviso-secundario"
+              onClick={() => setCorrigindo(false)}
+              disabled={salvando}
+            >
+              {t("crmv.cancel")}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="crmv-aviso-acoes">
+          <button
+            type="button"
+            className="crmv-aviso-botao"
+            onClick={() => void verificar()}
+            disabled={verificando || !token}
+          >
+            {verificando ? t("crmv.verifying") : t("crmv.verify")}
+          </button>
+          <button
+            type="button"
+            className="crmv-aviso-secundario"
+            onClick={() => setCorrigindo(true)}
+            disabled={verificando}
+          >
+            {t("crmv.fix")}
+          </button>
+        </div>
+      )}
+
       {erro && <p className="crmv-aviso-erro">{erro}</p>}
     </div>
   );

--- a/src/i18n/locales/en-US/common.json
+++ b/src/i18n/locales/en-US/common.json
@@ -146,9 +146,18 @@
     "blocked": "Your CRMV must be verified to access clinical data.",
     "verify": "Verify my CRMV",
     "verifying": "Verifying...",
-    "refused": "The registration was not accepted (status: {{situacao}}). Check the CRMV in your profile.",
+    "refused": "The registration was not accepted (status: {{situacao}}). Fix the CRMV and try again.",
     "failed": "Could not verify your CRMV right now. Please try again.",
-    "pending": "We could not confirm your CRMV. You can already use the system, but pets' clinical history only opens after verification."
+    "pending": "We could not confirm your CRMV. You can already use the system, but pets' clinical history only opens after verification.",
+    "fix": "Fix my CRMV",
+    "fixLabel": "CRMV",
+    "fixPlaceholder": "CRMV-SP 12345",
+    "fixHint": "Check the number and state code exactly as in your professional registry.",
+    "save": "Save and verify",
+    "saving": "Saving...",
+    "cancel": "Cancel",
+    "duplicate": "An account with this CRMV already exists.",
+    "saveFailed": "Could not save the CRMV right now. Please try again."
   },
   "petProfile": {
     "title": "Pet Profile",

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -146,9 +146,18 @@
     "blocked": "Seu CRMV precisa estar verificado para acessar dados clínicos.",
     "verify": "Verificar meu CRMV",
     "verifying": "Verificando...",
-    "refused": "O registro não foi aceito (situação: {{situacao}}). Confira o CRMV no seu cadastro.",
+    "refused": "O registro não foi aceito (situação: {{situacao}}). Corrija o CRMV e tente de novo.",
     "failed": "Não foi possível verificar seu CRMV agora. Tente novamente.",
-    "pending": "Não conseguimos confirmar seu CRMV. Você já pode usar o sistema, mas o histórico clínico dos pets só abre depois da verificação."
+    "pending": "Não conseguimos confirmar seu CRMV. Você já pode usar o sistema, mas o histórico clínico dos pets só abre depois da verificação.",
+    "fix": "Corrigir meu CRMV",
+    "fixLabel": "CRMV",
+    "fixPlaceholder": "CRMV-SP 12345",
+    "fixHint": "Confira o número e a UF, como constam no seu registro no conselho.",
+    "save": "Salvar e verificar",
+    "saving": "Salvando...",
+    "cancel": "Cancelar",
+    "duplicate": "Já existe uma conta com esse CRMV.",
+    "saveFailed": "Não foi possível salvar o CRMV agora. Tente novamente."
   },
   "petProfile": {
     "title": "Perfil do Pet",

--- a/src/pages/PublicCard/PublicCardPage.test.tsx
+++ b/src/pages/PublicCard/PublicCardPage.test.tsx
@@ -30,6 +30,7 @@ vi.mock("../../services/dashboard.service", () => ({
 
 vi.mock("../../services/crmv.service", () => ({
   verificarCrmv: vi.fn(),
+  corrigirMeuCrmv: vi.fn(),
 }));
 
 import { getPublicCard } from "../../services/card.service";

--- a/src/pages/PublicCard/PublicCardPage.tsx
+++ b/src/pages/PublicCard/PublicCardPage.tsx
@@ -178,7 +178,7 @@ export function PublicCardPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
-  const { token: authToken } = useAuth();
+  const { token: authToken, user } = useAuth();
   const [card, setCard] = useState<CarteiraDigitalPublicResponseDto | null>(
     null,
   );
@@ -392,6 +392,7 @@ export function PublicCardPage() {
             <CrmvAviso
               token={authToken}
               mensagem={t("publicCard.vetAccess.crmvRequired")}
+              crmvAtual={user?.crmv}
               onVerificado={() => void entrarComoVet()}
               className="vet-access-crmv"
             />

--- a/src/pages/VetDashboard/VetDashboardPage.test.tsx
+++ b/src/pages/VetDashboard/VetDashboardPage.test.tsx
@@ -31,6 +31,7 @@ vi.mock("../../services/dashboard.service", () => ({
 vi.mock("../../services/crmv.service", () => ({
   fetchCrmvStatus: vi.fn(),
   verificarCrmv: vi.fn(),
+  corrigirMeuCrmv: vi.fn(),
 }));
 
 import {

--- a/src/pages/VetDashboard/VetDashboardPage.tsx
+++ b/src/pages/VetDashboard/VetDashboardPage.tsx
@@ -171,6 +171,7 @@ export function VetDashboardPage() {
           <CrmvAviso
             token={token}
             mensagem={t("crmv.pending")}
+            crmvAtual={user?.crmv}
             onVerificado={() => void carregarStatusCrmv()}
             className="vet-dashboard-crmv-aviso"
           />

--- a/src/pages/VetPetProfile/VetPetProfilePage.test.tsx
+++ b/src/pages/VetPetProfile/VetPetProfilePage.test.tsx
@@ -42,6 +42,7 @@ vi.mock("../../services/pet-profile.service", () => ({
 
 vi.mock("../../services/crmv.service", () => ({
   verificarCrmv: vi.fn(),
+  corrigirMeuCrmv: vi.fn(),
 }));
 
 import {

--- a/src/pages/VetPetProfile/VetPetProfilePage.tsx
+++ b/src/pages/VetPetProfile/VetPetProfilePage.tsx
@@ -489,6 +489,7 @@ export function VetPetProfilePage() {
             <CrmvAviso
               token={token}
               mensagem={crmvBloqueado}
+              crmvAtual={user?.crmv}
               onVerificado={() => void load()}
             />
           </div>

--- a/src/services/crmv.service.ts
+++ b/src/services/crmv.service.ts
@@ -25,3 +25,17 @@ export function verificarCrmv(
     { method: "POST", token },
   );
 }
+
+/**
+ * Corrige o CRMV do próprio veterinário (`PATCH /veterinarios/me`).
+ *
+ * A API zera a verificação junto com a troca, então salvar sozinho não
+ * destrava nada — quem chama precisa verificar em seguida.
+ */
+export function corrigirMeuCrmv(token: string, crmv: string): Promise<void> {
+  return apiFetch("/veterinarios/me", {
+    method: "PATCH",
+    body: { crmv },
+    token,
+  });
+}


### PR DESCRIPTION
> Depende de **petcard-api#136** (`PATCH /veterinarios/me`). Mergear a API antes.

## Problema

O aviso de CRMV não verificado oferecia só "Verificar meu CRMV" — que reconsulta o registro **já guardado na conta**. Para quem digitou o CRMV errado no cadastro isso é um beco sem saída: reconsultar o mesmo número recusado nunca vai destravar, e a web não tem tela de perfil do veterinário onde arrumar o cadastro. A própria mensagem de recusa mandava "conferir o CRMV no seu cadastro", um lugar que não existe.

## Mudanças

- `CrmvAviso` ganha **"Corrigir meu CRMV"**: abre o campo já preenchido com o registro atual da conta e, no "Salvar e verificar", faz `PATCH /veterinarios/me` seguido da verificação. Uma ação só, porque a API zera a verificação ao trocar o CRMV — salvar sem conferir não abriria nada.
- Vale nos três lugares onde o aviso aparece: dashboard, carteira pública e prontuário.
- Conflito de CRMV (409) vira mensagem própria; a recusa do conselho continua mostrando a situação, agora apontando para a correção que está ali na tela.

## Verificação

Fluxo completo no navegador, contra a API e o Postgres reais, com `marcos.andrade` (CRMV `CRMV-SP 00000`, que o validador recusa):

1. Carteira pública → "Sou veterinário" → login → volta e tenta entrar sozinho → bloqueio com as duas opções.
2. "Corrigir meu CRMV" → campo vem com `CRMV-SP 00000`.
3. Salvando o CRMV da Camila → "Já existe uma conta com esse CRMV", form aberto.
4. Salvando um CRMV válido → verifica, vincula o pet e abre o prontuário do Thor.

O estado do seed foi restaurado depois do teste.

## Testes

105 passando; cobertura 85,7 / 82,2 / 73,3 / 85,7, acima da catraca (84/80/73/84).

Dois casos novos no `CrmvAviso`, ambos ligados a regra real (ADR-006): a correção salva o valor digitado e verifica na mesma ação; um CRMV corrigido que também é recusado **não** destrava a tela.