### PR TITLE
feat(perfil): tela de perfil do veterinário

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "petcard-web",
       "version": "0.0.0",
       "dependencies": {
-        "@petcardorg/shared": "^0.18.0",
+        "@petcardorg/shared": "^0.19.0",
         "html5-qrcode": "^2.3.8",
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -1394,9 +1394,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.18.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.18.0/6a3d3c6ed40357015b3a58ace8fb7050e13529d7",
-      "integrity": "sha512-WbGU7FpnwR7iwiTdD19fAQJ/qEkXCOi6aTJJ+0oRVaqs+HcLIW82/kFfSNoAxIuzbSdk9lrt5nJWzzrVoeWl4Q==",
+      "version": "0.19.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.19.0/2dbf6d3afa8dbd9eb4783308c4d64dbba9517243",
+      "integrity": "sha512-944t8LEsrPl/Uwirkyh3qzQAzjFkgRYYk9M5rp28+GOMoll96qIlnv69HbcDGyWL8v3jC/OSyGIDFF4G3E6aWw==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "*.{ts,tsx,json,css,md}": "prettier --write"
   },
   "dependencies": {
-    "@petcardorg/shared": "^0.18.0",
+    "@petcardorg/shared": "^0.19.0",
     "html5-qrcode": "^2.3.8",
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -14,6 +14,7 @@ function renderWithAuth(auth: Partial<AuthContextValue>) {
     login: async () => {},
     register: async () => {},
     logout: () => {},
+    refreshUser: async () => {},
     ...auth,
   };
 

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -120,6 +120,37 @@ describe("AuthProvider / useAuth", () => {
     expect(result.current.loading).toBe(false);
   });
 
+  it("refreshUser reconsulta o perfil e atualiza o usuário exibido", async () => {
+    loginMock.mockResolvedValue({ access_token: "jwt-1", user: vetUser });
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await result.current.login("vet@petcard.com", "senha123");
+    });
+
+    const vetAtualizado = { ...vetUser, nome: "Dra. Camila Ferreira" };
+    profileMock.mockResolvedValue(vetAtualizado);
+
+    await act(async () => {
+      await result.current.refreshUser();
+    });
+
+    expect(profileMock).toHaveBeenCalledWith("jwt-1");
+    expect(result.current.user).toEqual(vetAtualizado);
+    // Token não deve ser afetado por uma simples atualização de perfil.
+    expect(result.current.token).toBe("jwt-1");
+  });
+
+  it("refreshUser não chama a API sem token (deslogado)", async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await result.current.refreshUser();
+    });
+
+    expect(profileMock).not.toHaveBeenCalled();
+  });
+
   it("descarta o token salvo quando o perfil falha (token inválido)", async () => {
     localStorage.setItem(TOKEN_KEY, "jwt-stale");
     profileMock.mockRejectedValue(new Error("401"));

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -65,9 +65,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setState({ token: null, user: null, loading: false });
   }, []);
 
+  const refreshUser = useCallback(async () => {
+    if (!state.token) return;
+    const user = await getVeterinarioProfile(state.token);
+    setState((prev) => ({ ...prev, user }));
+  }, [state.token]);
+
   const value = useMemo(
-    () => ({ ...state, login, register, logout }),
-    [state, login, register, logout],
+    () => ({ ...state, login, register, logout, refreshUser }),
+    [state, login, register, logout, refreshUser],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -17,6 +17,8 @@ export interface AuthContextValue extends AuthState {
    */
   register: (dto: VetRegisterRequest) => Promise<void>;
   logout: () => void;
+  /** Reconsulta `GET /auth/veterinario/profile` para atualizar nome/foto exibidos. */
+  refreshUser: () => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/src/i18n/locales/en-US/common.json
+++ b/src/i18n/locales/en-US/common.json
@@ -284,5 +284,40 @@
     "noCameraTitle": "Camera unavailable",
     "noCameraDescription": "No camera was found on this device.",
     "backToDashboard": "Back to dashboard"
+  },
+  "vetProfile": {
+    "title": "My profile",
+    "back": "Back",
+    "loading": "Loading...",
+    "error": "Failed to load profile",
+    "retry": "Try again",
+    "photo": {
+      "change": "Change photo",
+      "uploading": "Uploading photo...",
+      "error": "Could not upload the photo. Please try again."
+    },
+    "form": {
+      "nome": "Full name",
+      "email": "Email",
+      "telefone": "Phone",
+      "telefonePlaceholder": "(11) 99999-0000",
+      "submit": "Save changes",
+      "submitting": "Saving...",
+      "success": "Profile updated.",
+      "duplicateEmail": "An account with this email already exists.",
+      "invalid": "Please check the information provided.",
+      "genericError": "Could not save. Please try again."
+    },
+    "danger": {
+      "title": "Delete account",
+      "description": "Deleting your account removes your access to PetCard. This action cannot be undone.",
+      "button": "Delete account",
+      "confirmTitle": "Are you sure?",
+      "confirmDescription": "Your veterinarian account will be permanently deleted. Access cannot be recovered afterward.",
+      "confirmButton": "Yes, delete permanently",
+      "cancel": "Cancel",
+      "deleting": "Deleting...",
+      "error": "Could not delete the account. Please try again."
+    }
   }
 }

--- a/src/i18n/locales/en-US/common.json
+++ b/src/i18n/locales/en-US/common.json
@@ -298,13 +298,15 @@
     },
     "form": {
       "nome": "Full name",
+      "crmv": "CRMV",
+      "crmvHint": "Changing the CRMV resets the current verification — you'll need to verify again.",
       "email": "Email",
       "telefone": "Phone",
       "telefonePlaceholder": "(11) 99999-0000",
       "submit": "Save changes",
       "submitting": "Saving...",
       "success": "Profile updated.",
-      "duplicateEmail": "An account with this email already exists.",
+      "duplicate": "An account with this email or CRMV already exists.",
       "invalid": "Please check the information provided.",
       "genericError": "Could not save. Please try again."
     },

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -298,13 +298,15 @@
     },
     "form": {
       "nome": "Nome completo",
+      "crmv": "CRMV",
+      "crmvHint": "Alterar o CRMV zera a verificação atual — você vai precisar verificar de novo.",
       "email": "E-mail",
       "telefone": "Telefone",
       "telefonePlaceholder": "(11) 99999-0000",
       "submit": "Salvar alterações",
       "submitting": "Salvando...",
       "success": "Perfil atualizado.",
-      "duplicateEmail": "Já existe uma conta com esse e-mail.",
+      "duplicate": "Já existe uma conta com esse e-mail ou CRMV.",
       "invalid": "Confira os dados informados.",
       "genericError": "Não foi possível salvar. Tente de novo."
     },

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -284,5 +284,40 @@
     "noCameraTitle": "Câmera indisponível",
     "noCameraDescription": "Nenhuma câmera foi encontrada neste dispositivo.",
     "backToDashboard": "Voltar ao dashboard"
+  },
+  "vetProfile": {
+    "title": "Meu perfil",
+    "back": "Voltar",
+    "loading": "Carregando...",
+    "error": "Erro ao carregar o perfil",
+    "retry": "Tentar novamente",
+    "photo": {
+      "change": "Trocar foto",
+      "uploading": "Enviando foto...",
+      "error": "Não foi possível enviar a foto. Tente de novo."
+    },
+    "form": {
+      "nome": "Nome completo",
+      "email": "E-mail",
+      "telefone": "Telefone",
+      "telefonePlaceholder": "(11) 99999-0000",
+      "submit": "Salvar alterações",
+      "submitting": "Salvando...",
+      "success": "Perfil atualizado.",
+      "duplicateEmail": "Já existe uma conta com esse e-mail.",
+      "invalid": "Confira os dados informados.",
+      "genericError": "Não foi possível salvar. Tente de novo."
+    },
+    "danger": {
+      "title": "Excluir conta",
+      "description": "Excluir sua conta remove seu acesso ao PetCard. Essa ação não pode ser desfeita.",
+      "button": "Excluir conta",
+      "confirmTitle": "Tem certeza?",
+      "confirmDescription": "Seu cadastro de veterinário será apagado definitivamente. Não é possível recuperar o acesso depois.",
+      "confirmButton": "Sim, excluir definitivamente",
+      "cancel": "Cancelar",
+      "deleting": "Excluindo...",
+      "error": "Não foi possível excluir a conta. Tente de novo."
+    }
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import { VetLoginPage } from "./pages/VetLogin/VetLoginPage";
 import { VetRegisterPage } from "./pages/VetRegister/VetRegisterPage";
 import { VetDashboardPage } from "./pages/VetDashboard/VetDashboardPage";
 import { VetPetProfilePage } from "./pages/VetPetProfile/VetPetProfilePage";
+import { VetProfilePage } from "./pages/VetProfile/VetProfilePage";
 import { NotFoundPage } from "./pages/NotFound/NotFoundPage";
 
 import "./index.css";
@@ -66,6 +67,14 @@ createRoot(document.getElementById("root")!).render(
             element={
               <ProtectedRoute>
                 <VetPetProfilePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/vet/profile"
+            element={
+              <ProtectedRoute>
+                <VetProfilePage />
               </ProtectedRoute>
             }
           />

--- a/src/pages/VetDashboard/VetDashboardPage.css
+++ b/src/pages/VetDashboard/VetDashboardPage.css
@@ -42,14 +42,32 @@
   gap: 1rem;
 }
 
+.vet-dashboard-user-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+}
+
+.vet-dashboard-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.vet-dashboard-avatar-fallback {
+  color: #9caab4;
+  flex-shrink: 0;
+}
+
 .vet-dashboard-username {
   font-size: 0.875rem;
   color: #14313f;
   font-weight: 500;
-  text-decoration: none;
 }
 
-.vet-dashboard-username:hover {
+.vet-dashboard-user-link:hover .vet-dashboard-username {
   color: #107fa8;
   text-decoration: underline;
 }

--- a/src/pages/VetDashboard/VetDashboardPage.css
+++ b/src/pages/VetDashboard/VetDashboardPage.css
@@ -46,6 +46,12 @@
   font-size: 0.875rem;
   color: #14313f;
   font-weight: 500;
+  text-decoration: none;
+}
+
+.vet-dashboard-username:hover {
+  color: #107fa8;
+  text-decoration: underline;
 }
 
 .vet-dashboard-logout {

--- a/src/pages/VetDashboard/VetDashboardPage.test.tsx
+++ b/src/pages/VetDashboard/VetDashboardPage.test.tsx
@@ -13,6 +13,9 @@ const logoutMock = vi.fn();
 
 vi.mock("react-router-dom", () => ({
   useNavigate: () => navigateMock,
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
 }));
 
 vi.mock("../../hooks/useAuth", () => ({

--- a/src/pages/VetDashboard/VetDashboardPage.tsx
+++ b/src/pages/VetDashboard/VetDashboardPage.tsx
@@ -7,6 +7,7 @@ import {
   IoSearch,
   IoChevronForward,
   IoTrashOutline,
+  IoPersonCircleOutline,
 } from "react-icons/io5";
 import { useAuth } from "../../hooks/useAuth";
 import { LanguageSwitcher } from "../../components/LanguageSwitcher/LanguageSwitcher";
@@ -155,8 +156,20 @@ export function VetDashboardPage() {
         </div>
         <div className="vet-dashboard-user">
           <LanguageSwitcher />
-          <Link to="/vet/profile" className="vet-dashboard-username">
-            {user?.nome}
+          <Link to="/vet/profile" className="vet-dashboard-user-link">
+            {user?.foto_url ? (
+              <img
+                src={user.foto_url}
+                alt={user.nome}
+                className="vet-dashboard-avatar"
+              />
+            ) : (
+              <IoPersonCircleOutline
+                size={28}
+                className="vet-dashboard-avatar-fallback"
+              />
+            )}
+            <span className="vet-dashboard-username">{user?.nome}</span>
           </Link>
           <button
             type="button"

--- a/src/pages/VetDashboard/VetDashboardPage.tsx
+++ b/src/pages/VetDashboard/VetDashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   IoPaw,
@@ -155,7 +155,9 @@ export function VetDashboardPage() {
         </div>
         <div className="vet-dashboard-user">
           <LanguageSwitcher />
-          <span className="vet-dashboard-username">{user?.nome}</span>
+          <Link to="/vet/profile" className="vet-dashboard-username">
+            {user?.nome}
+          </Link>
           <button
             type="button"
             className="vet-dashboard-logout"

--- a/src/pages/VetProfile/VetProfilePage.css
+++ b/src/pages/VetProfile/VetProfilePage.css
@@ -1,0 +1,296 @@
+.vet-profile {
+  min-height: 100vh;
+  background: #f6fbfe;
+}
+
+/* ── Header ── */
+
+.vet-profile-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 2rem;
+  background: #fff;
+  border-bottom: 1px solid #d8eef6;
+}
+
+.vet-profile-back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: #107fa8;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.vet-profile-back:hover {
+  background: #e6f7fc;
+}
+
+.vet-profile-header-title {
+  font-size: 1.125rem;
+  font-weight: 800;
+  color: #14313f;
+}
+
+/* ── Content ── */
+
+.vet-profile-content {
+  padding: 1.5rem 2rem 3rem;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+/* ── Photo ── */
+
+.vet-profile-photo-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.625rem;
+  margin-bottom: 2rem;
+}
+
+.vet-profile-photo,
+.vet-profile-avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.vet-profile-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #e6f7fc;
+}
+
+.vet-profile-photo-input {
+  display: none;
+}
+
+.vet-profile-photo-button {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.4rem 0.875rem;
+  border: 1px solid #d8eef6;
+  border-radius: 8px;
+  background: #fff;
+  color: #107fa8;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.vet-profile-photo-button:hover:not(:disabled) {
+  background: #e6f7fc;
+  border-color: #27a9d8;
+}
+
+.vet-profile-photo-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.vet-profile-photo-error {
+  margin: 0;
+  color: #e63946;
+  font-size: 0.8125rem;
+}
+
+/* ── Form ── */
+
+.vet-profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: #fff;
+  border: 1px solid #d8eef6;
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+.vet-profile-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+}
+
+.vet-profile-field label {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: #14313f;
+}
+
+.vet-profile-field input {
+  padding: 0.75rem 1rem;
+  border: 1px solid #d8eef6;
+  border-radius: 12px;
+  font-size: 1rem;
+  color: #14313f;
+  background: #fff;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.vet-profile-field input::placeholder {
+  color: #607d8b;
+}
+
+.vet-profile-field input:focus {
+  border-color: #27a9d8;
+  box-shadow: 0 0 0 3px rgb(39 169 216 / 12%);
+}
+
+.vet-profile-field input:disabled {
+  background: #f6fbfe;
+  cursor: not-allowed;
+}
+
+.vet-profile-error {
+  margin: 0.5rem 0 0;
+  padding: 1rem;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 12px;
+  color: #e63946;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.vet-profile-success {
+  margin: 0.5rem 0 0;
+  padding: 1rem;
+  background: #e5f8ee;
+  border: 1px solid #b7e9cd;
+  border-radius: 12px;
+  color: #06a77d;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.vet-profile-submit {
+  margin-top: 1rem;
+  padding: 0.875rem;
+  border: none;
+  border-radius: 12px;
+  background: #27a9d8;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.vet-profile-submit:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.vet-profile-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── Danger zone ── */
+
+.vet-profile-danger {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid #fecaca;
+  border-radius: 16px;
+  background: #fef2f2;
+}
+
+.vet-profile-danger h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: #e63946;
+}
+
+.vet-profile-danger p {
+  margin: 0 0 1rem;
+  color: #7a2b30;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.vet-profile-danger-button {
+  padding: 0.625rem 1rem;
+  border: 1px solid #e63946;
+  border-radius: 10px;
+  background: #fff;
+  color: #e63946;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    color 0.2s;
+}
+
+.vet-profile-danger-button:hover {
+  background: #e63946;
+  color: #fff;
+}
+
+.vet-profile-danger-confirm h4 {
+  margin: 0 0 0.5rem;
+  color: #7a2b30;
+  font-size: 0.9375rem;
+}
+
+.vet-profile-danger-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.vet-profile-danger-cancel {
+  padding: 0.625rem 1rem;
+  border: 1px solid #d8eef6;
+  border-radius: 10px;
+  background: #fff;
+  color: #14313f;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.vet-profile-danger-cancel:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.vet-profile-danger-confirm-button {
+  padding: 0.625rem 1rem;
+  border: none;
+  border-radius: 10px;
+  background: #e63946;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.vet-profile-danger-confirm-button:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.vet-profile-danger-confirm-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/pages/VetProfile/VetProfilePage.css
+++ b/src/pages/VetProfile/VetProfilePage.css
@@ -158,6 +158,12 @@
   cursor: not-allowed;
 }
 
+.vet-profile-hint {
+  color: #607d8b;
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
 .vet-profile-error {
   margin: 0.5rem 0 0;
   padding: 1rem;

--- a/src/pages/VetProfile/VetProfilePage.test.tsx
+++ b/src/pages/VetProfile/VetProfilePage.test.tsx
@@ -61,8 +61,18 @@ describe("VetProfilePage", () => {
     expect(screen.getByLabelText("Nome completo")).toHaveValue(
       "Dra. Camila Ferreira",
     );
+    expect(screen.getByLabelText("CRMV")).toHaveValue("CRMV-SP 12345");
     expect(screen.getByLabelText("E-mail")).toHaveValue("camila@vet.com");
     expect(screen.getByLabelText("Telefone")).toHaveValue("11999990000");
+  });
+
+  it("mostra a foto salva em vez do ícone padrão quando há foto_url", () => {
+    authUser.foto_url = "https://s3/vets/foto.png";
+    render(<VetProfilePage />);
+
+    expect(
+      screen.getByRole("img", { name: "Dra. Camila Ferreira" }),
+    ).toHaveAttribute("src", "https://s3/vets/foto.png");
   });
 
   it("volta ao dashboard ao clicar em voltar", async () => {
@@ -87,7 +97,7 @@ describe("VetProfilePage", () => {
     expect(clickSpy).toHaveBeenCalled();
   });
 
-  it("salva nome, e-mail e telefone e mostra sucesso", async () => {
+  it("salva nome, crmv, e-mail e telefone e mostra sucesso", async () => {
     updateVeterinarioMock.mockResolvedValue(undefined);
     refreshUserMock.mockResolvedValue(undefined);
     render(<VetProfilePage />);
@@ -95,6 +105,8 @@ describe("VetProfilePage", () => {
     const user = userEvent.setup();
     await user.clear(screen.getByLabelText("Nome completo"));
     await user.type(screen.getByLabelText("Nome completo"), "Dra. Camila S.");
+    await user.clear(screen.getByLabelText("CRMV"));
+    await user.type(screen.getByLabelText("CRMV"), "CRMV-SP 54321");
     await user.clear(screen.getByLabelText("E-mail"));
     await user.type(screen.getByLabelText("E-mail"), "camila.s@vet.com");
     await user.clear(screen.getByLabelText("Telefone"));
@@ -104,6 +116,7 @@ describe("VetProfilePage", () => {
     await waitFor(() =>
       expect(updateVeterinarioMock).toHaveBeenCalledWith("jwt-123", {
         nome: "Dra. Camila S.",
+        crmv: "CRMV-SP 54321",
         email: "camila.s@vet.com",
         telefone: "11888887777",
       }),
@@ -129,7 +142,7 @@ describe("VetProfilePage", () => {
     );
   });
 
-  it("avisa sobre e-mail duplicado no 409", async () => {
+  it("avisa sobre e-mail ou CRMV duplicado no 409", async () => {
     updateVeterinarioMock.mockRejectedValue(new ApiError(409, "Conflict"));
     render(<VetProfilePage />);
 
@@ -137,7 +150,7 @@ describe("VetProfilePage", () => {
     await user.click(screen.getByRole("button", { name: "Salvar alterações" }));
 
     expect(
-      await screen.findByText("Já existe uma conta com esse e-mail."),
+      await screen.findByText("Já existe uma conta com esse e-mail ou CRMV."),
     ).toBeInTheDocument();
   });
 

--- a/src/pages/VetProfile/VetProfilePage.test.tsx
+++ b/src/pages/VetProfile/VetProfilePage.test.tsx
@@ -1,0 +1,242 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VetProfilePage } from "./VetProfilePage";
+import { ApiError } from "../../services/api";
+
+const navigateMock = vi.fn();
+const logoutMock = vi.fn();
+const refreshUserMock = vi.fn();
+
+const authUser = {
+  id: "vet-1",
+  nome: "Dra. Camila Ferreira",
+  email: "camila@vet.com",
+  crmv: "CRMV-SP 12345",
+  role: "VET",
+  telefone: "11999990000",
+  foto_url: undefined as string | undefined,
+};
+
+vi.mock("../../hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: authUser,
+    token: "jwt-123",
+    logout: logoutMock,
+    refreshUser: refreshUserMock,
+  }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+const uploadImageMock = vi.fn();
+vi.mock("../../services/upload.service", () => ({
+  uploadImage: (...args: unknown[]) => uploadImageMock(...args),
+}));
+
+const updateVeterinarioMock = vi.fn();
+const deleteVeterinarioMock = vi.fn();
+vi.mock("../../services/vet-profile.service", () => ({
+  updateVeterinario: (...args: unknown[]) => updateVeterinarioMock(...args),
+  deleteVeterinario: (...args: unknown[]) => deleteVeterinarioMock(...args),
+}));
+
+describe("VetProfilePage", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    logoutMock.mockReset();
+    refreshUserMock.mockReset();
+    uploadImageMock.mockReset();
+    updateVeterinarioMock.mockReset();
+    deleteVeterinarioMock.mockReset();
+    authUser.foto_url = undefined;
+    authUser.telefone = "11999990000";
+  });
+
+  it("pré-preenche o formulário com os dados do veterinário logado", () => {
+    render(<VetProfilePage />);
+
+    expect(screen.getByLabelText("Nome completo")).toHaveValue(
+      "Dra. Camila Ferreira",
+    );
+    expect(screen.getByLabelText("E-mail")).toHaveValue("camila@vet.com");
+    expect(screen.getByLabelText("Telefone")).toHaveValue("11999990000");
+  });
+
+  it("volta ao dashboard ao clicar em voltar", async () => {
+    render(<VetProfilePage />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Voltar" }));
+
+    expect(navigateMock).toHaveBeenCalledWith("/vet/dashboard");
+  });
+
+  it("o botão trocar foto aciona o input de arquivo escondido", async () => {
+    render(<VetProfilePage />);
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const clickSpy = vi.spyOn(input, "click");
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Trocar foto" }));
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it("salva nome, e-mail e telefone e mostra sucesso", async () => {
+    updateVeterinarioMock.mockResolvedValue(undefined);
+    refreshUserMock.mockResolvedValue(undefined);
+    render(<VetProfilePage />);
+
+    const user = userEvent.setup();
+    await user.clear(screen.getByLabelText("Nome completo"));
+    await user.type(screen.getByLabelText("Nome completo"), "Dra. Camila S.");
+    await user.clear(screen.getByLabelText("E-mail"));
+    await user.type(screen.getByLabelText("E-mail"), "camila.s@vet.com");
+    await user.clear(screen.getByLabelText("Telefone"));
+    await user.type(screen.getByLabelText("Telefone"), "11888887777");
+    await user.click(screen.getByRole("button", { name: "Salvar alterações" }));
+
+    await waitFor(() =>
+      expect(updateVeterinarioMock).toHaveBeenCalledWith("jwt-123", {
+        nome: "Dra. Camila S.",
+        email: "camila.s@vet.com",
+        telefone: "11888887777",
+      }),
+    );
+    expect(refreshUserMock).toHaveBeenCalled();
+    expect(await screen.findByText("Perfil atualizado.")).toBeInTheDocument();
+  });
+
+  it("envia telefone vazio como indefinido", async () => {
+    updateVeterinarioMock.mockResolvedValue(undefined);
+    refreshUserMock.mockResolvedValue(undefined);
+    authUser.telefone = "";
+    render(<VetProfilePage />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Salvar alterações" }));
+
+    await waitFor(() =>
+      expect(updateVeterinarioMock).toHaveBeenCalledWith(
+        "jwt-123",
+        expect.objectContaining({ telefone: undefined }),
+      ),
+    );
+  });
+
+  it("avisa sobre e-mail duplicado no 409", async () => {
+    updateVeterinarioMock.mockRejectedValue(new ApiError(409, "Conflict"));
+    render(<VetProfilePage />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Salvar alterações" }));
+
+    expect(
+      await screen.findByText("Já existe uma conta com esse e-mail."),
+    ).toBeInTheDocument();
+  });
+
+  it("desloga em 401 ao salvar", async () => {
+    updateVeterinarioMock.mockRejectedValue(new ApiError(401, "Unauthorized"));
+    render(<VetProfilePage />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Salvar alterações" }));
+
+    await waitFor(() => expect(logoutMock).toHaveBeenCalled());
+  });
+
+  it("troca a foto: upload seguido de PATCH e refresh do usuário", async () => {
+    uploadImageMock.mockResolvedValue({ url: "https://s3/vets/foto.png" });
+    updateVeterinarioMock.mockResolvedValue(undefined);
+    refreshUserMock.mockResolvedValue(undefined);
+    render(<VetProfilePage />);
+
+    const file = new File(["conteudo"], "foto.png", { type: "image/png" });
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const user = userEvent.setup();
+    await user.upload(input, file);
+
+    await waitFor(() =>
+      expect(uploadImageMock).toHaveBeenCalledWith("jwt-123", file, "vets"),
+    );
+    expect(updateVeterinarioMock).toHaveBeenCalledWith("jwt-123", {
+      foto_url: "https://s3/vets/foto.png",
+    });
+    expect(refreshUserMock).toHaveBeenCalled();
+  });
+
+  it("exclusão de conta exige duas etapas de confirmação", async () => {
+    render(<VetProfilePage />);
+
+    expect(
+      screen.queryByRole("button", { name: "Sim, excluir definitivamente" }),
+    ).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Excluir conta" }));
+
+    expect(
+      screen.getByRole("button", { name: "Sim, excluir definitivamente" }),
+    ).toBeInTheDocument();
+    expect(deleteVeterinarioMock).not.toHaveBeenCalled();
+  });
+
+  it("cancelar a exclusão fecha a confirmação sem chamar a API", async () => {
+    render(<VetProfilePage />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Excluir conta" }));
+    await user.click(screen.getByRole("button", { name: "Cancelar" }));
+
+    expect(
+      screen.queryByRole("button", { name: "Sim, excluir definitivamente" }),
+    ).not.toBeInTheDocument();
+    expect(deleteVeterinarioMock).not.toHaveBeenCalled();
+  });
+
+  it("confirma a exclusão, limpa a sessão e redireciona ao login", async () => {
+    deleteVeterinarioMock.mockResolvedValue(undefined);
+    render(<VetProfilePage />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Excluir conta" }));
+    await user.click(
+      screen.getByRole("button", { name: "Sim, excluir definitivamente" }),
+    );
+
+    await waitFor(() =>
+      expect(deleteVeterinarioMock).toHaveBeenCalledWith("jwt-123"),
+    );
+    expect(logoutMock).toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith("/vet/login", { replace: true });
+  });
+
+  it("mostra erro e permite tentar de novo se a exclusão falhar", async () => {
+    deleteVeterinarioMock.mockRejectedValue(
+      new ApiError(500, "Internal Server Error"),
+    );
+    render(<VetProfilePage />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Excluir conta" }));
+    await user.click(
+      screen.getByRole("button", { name: "Sim, excluir definitivamente" }),
+    );
+
+    expect(
+      await screen.findByText(
+        "Não foi possível excluir a conta. Tente de novo.",
+      ),
+    ).toBeInTheDocument();
+    expect(logoutMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/VetProfile/VetProfilePage.tsx
+++ b/src/pages/VetProfile/VetProfilePage.tsx
@@ -24,6 +24,7 @@ export function VetProfilePage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [nome, setNome] = useState(user?.nome ?? "");
+  const [crmv, setCrmv] = useState(user?.crmv ?? "");
   const [email, setEmail] = useState(user?.email ?? "");
   const [telefone, setTelefone] = useState(user?.telefone ?? "");
   const [saving, setSaving] = useState(false);
@@ -69,6 +70,7 @@ export function VetProfilePage() {
     try {
       await updateVeterinario(token, {
         nome: nome.trim(),
+        crmv: crmv.trim(),
         email: email.trim(),
         telefone: telefone.trim() === "" ? undefined : telefone.trim(),
       });
@@ -80,7 +82,7 @@ export function VetProfilePage() {
         return;
       }
       if (err instanceof ApiError && err.status === 409) {
-        setSaveError(t("vetProfile.form.duplicateEmail"));
+        setSaveError(t("vetProfile.form.duplicate"));
       } else if (err instanceof ApiError && err.status === 400) {
         setSaveError(err.detail ?? t("vetProfile.form.invalid"));
       } else {
@@ -178,6 +180,23 @@ export function VetProfilePage() {
               autoComplete="name"
               disabled={saving}
             />
+          </div>
+
+          <div className="vet-profile-field">
+            <label htmlFor="crmv">{t("vetProfile.form.crmv")}</label>
+            <input
+              id="crmv"
+              type="text"
+              value={crmv}
+              onChange={(e) => setCrmv(e.target.value)}
+              required
+              minLength={3}
+              maxLength={30}
+              disabled={saving}
+            />
+            <small className="vet-profile-hint">
+              {t("vetProfile.form.crmvHint")}
+            </small>
           </div>
 
           <div className="vet-profile-field">

--- a/src/pages/VetProfile/VetProfilePage.tsx
+++ b/src/pages/VetProfile/VetProfilePage.tsx
@@ -1,0 +1,281 @@
+import { useRef, useState } from "react";
+import type { ChangeEvent, FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import {
+  IoArrowBack,
+  IoCameraOutline,
+  IoPersonCircleOutline,
+  IoWarningOutline,
+} from "react-icons/io5";
+import { useAuth } from "../../hooks/useAuth";
+import { ApiError } from "../../services/api";
+import { uploadImage } from "../../services/upload.service";
+import {
+  updateVeterinario,
+  deleteVeterinario,
+} from "../../services/vet-profile.service";
+import "./VetProfilePage.css";
+
+export function VetProfilePage() {
+  const { t } = useTranslation();
+  const { user, token, logout, refreshUser } = useAuth();
+  const navigate = useNavigate();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [nome, setNome] = useState(user?.nome ?? "");
+  const [email, setEmail] = useState(user?.email ?? "");
+  const [telefone, setTelefone] = useState(user?.telefone ?? "");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  const [uploadingPhoto, setUploadingPhoto] = useState(false);
+  const [photoError, setPhotoError] = useState<string | null>(null);
+
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  async function handlePhotoChange(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file || !token) return;
+
+    setPhotoError(null);
+    setUploadingPhoto(true);
+    try {
+      const { url } = await uploadImage(token, file, "vets");
+      await updateVeterinario(token, { foto_url: url });
+      await refreshUser();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        logout();
+        return;
+      }
+      setPhotoError(t("vetProfile.photo.error"));
+    } finally {
+      setUploadingPhoto(false);
+    }
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!token) return;
+
+    setSaveError(null);
+    setSaveSuccess(false);
+    setSaving(true);
+    try {
+      await updateVeterinario(token, {
+        nome: nome.trim(),
+        email: email.trim(),
+        telefone: telefone.trim() === "" ? undefined : telefone.trim(),
+      });
+      await refreshUser();
+      setSaveSuccess(true);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        logout();
+        return;
+      }
+      if (err instanceof ApiError && err.status === 409) {
+        setSaveError(t("vetProfile.form.duplicateEmail"));
+      } else if (err instanceof ApiError && err.status === 400) {
+        setSaveError(err.detail ?? t("vetProfile.form.invalid"));
+      } else {
+        setSaveError(t("vetProfile.form.genericError"));
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!token) return;
+
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await deleteVeterinario(token);
+      logout();
+      navigate("/vet/login", { replace: true });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        logout();
+        navigate("/vet/login", { replace: true });
+        return;
+      }
+      setDeleteError(t("vetProfile.danger.error"));
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <div className="vet-profile">
+      <header className="vet-profile-header">
+        <button
+          type="button"
+          className="vet-profile-back"
+          aria-label={t("vetProfile.back")}
+          onClick={() => navigate("/vet/dashboard")}
+        >
+          <IoArrowBack size={20} />
+        </button>
+        <span className="vet-profile-header-title">
+          {t("vetProfile.title")}
+        </span>
+      </header>
+
+      <main className="vet-profile-content">
+        <div className="vet-profile-photo-section">
+          {user?.foto_url ? (
+            <img
+              src={user.foto_url}
+              alt={user.nome}
+              className="vet-profile-photo"
+            />
+          ) : (
+            <div className="vet-profile-avatar">
+              <IoPersonCircleOutline size={56} color="#27a9d8" />
+            </div>
+          )}
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            className="vet-profile-photo-input"
+            onChange={handlePhotoChange}
+          />
+          <button
+            type="button"
+            className="vet-profile-photo-button"
+            disabled={uploadingPhoto}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <IoCameraOutline size={16} />
+            {uploadingPhoto
+              ? t("vetProfile.photo.uploading")
+              : t("vetProfile.photo.change")}
+          </button>
+          {photoError && (
+            <p className="vet-profile-photo-error">{photoError}</p>
+          )}
+        </div>
+
+        <form className="vet-profile-form" onSubmit={handleSubmit}>
+          <div className="vet-profile-field">
+            <label htmlFor="nome">{t("vetProfile.form.nome")}</label>
+            <input
+              id="nome"
+              type="text"
+              value={nome}
+              onChange={(e) => setNome(e.target.value)}
+              required
+              minLength={2}
+              maxLength={120}
+              autoComplete="name"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="vet-profile-field">
+            <label htmlFor="email">{t("vetProfile.form.email")}</label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              maxLength={254}
+              autoComplete="email"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="vet-profile-field">
+            <label htmlFor="telefone">{t("vetProfile.form.telefone")}</label>
+            <input
+              id="telefone"
+              type="tel"
+              value={telefone}
+              onChange={(e) => setTelefone(e.target.value)}
+              placeholder={t("vetProfile.form.telefonePlaceholder")}
+              maxLength={20}
+              autoComplete="tel"
+              disabled={saving}
+            />
+          </div>
+
+          {saveError && <p className="vet-profile-error">{saveError}</p>}
+          {saveSuccess && (
+            <p className="vet-profile-success">
+              {t("vetProfile.form.success")}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            className="vet-profile-submit"
+            disabled={saving}
+          >
+            {saving
+              ? t("vetProfile.form.submitting")
+              : t("vetProfile.form.submit")}
+          </button>
+        </form>
+
+        <div className="vet-profile-danger">
+          <h3>
+            <IoWarningOutline size={18} /> {t("vetProfile.danger.title")}
+          </h3>
+
+          {!confirmingDelete ? (
+            <>
+              <p>{t("vetProfile.danger.description")}</p>
+              <button
+                type="button"
+                className="vet-profile-danger-button"
+                onClick={() => setConfirmingDelete(true)}
+              >
+                {t("vetProfile.danger.button")}
+              </button>
+            </>
+          ) : (
+            <div className="vet-profile-danger-confirm">
+              <h4>{t("vetProfile.danger.confirmTitle")}</h4>
+              <p>{t("vetProfile.danger.confirmDescription")}</p>
+              {deleteError && (
+                <p className="vet-profile-error">{deleteError}</p>
+              )}
+              <div className="vet-profile-danger-actions">
+                <button
+                  type="button"
+                  className="vet-profile-danger-cancel"
+                  disabled={deleting}
+                  onClick={() => {
+                    setConfirmingDelete(false);
+                    setDeleteError(null);
+                  }}
+                >
+                  {t("vetProfile.danger.cancel")}
+                </button>
+                <button
+                  type="button"
+                  className="vet-profile-danger-confirm-button"
+                  disabled={deleting}
+                  onClick={() => void handleDelete()}
+                >
+                  {deleting
+                    ? t("vetProfile.danger.deleting")
+                    : t("vetProfile.danger.confirmButton")}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,6 +2,7 @@ const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
 
 export interface ApiFetchOptions {
   method?: string;
+  /** `FormData` vai direto no fetch, sem JSON.stringify nem Content-Type manual. */
   body?: unknown;
   token?: string;
 }
@@ -11,10 +12,14 @@ export async function apiFetch<T>(
   options: ApiFetchOptions = {},
 ): Promise<T> {
   const { method = "GET", body, token } = options;
+  const isFormData = body instanceof FormData;
 
   const headers: Record<string, string> = {};
 
-  if (body !== undefined) {
+  // Para FormData o browser define Content-Type sozinho, com o boundary do
+  // multipart — setar aqui manda a requisição sem boundary e a api não
+  // consegue parsear as partes.
+  if (body !== undefined && !isFormData) {
     headers["Content-Type"] = "application/json";
   }
 
@@ -25,7 +30,11 @@ export async function apiFetch<T>(
   const res = await fetch(`${API_URL}${path}`, {
     method,
     headers,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
+    body: isFormData
+      ? body
+      : body !== undefined
+        ? JSON.stringify(body)
+        : undefined,
   });
 
   if (!res.ok) {

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -12,6 +12,7 @@ export interface VetUser {
   crmv: string;
   role: string;
   telefone?: string;
+  foto_url?: string;
 }
 
 export interface VetLoginResponse {

--- a/src/services/upload.service.test.ts
+++ b/src/services/upload.service.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { uploadImage } from "./upload.service";
+
+const BASE = "http://localhost:3000";
+
+describe("uploadImage", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: () => Promise.resolve({ url: "https://s3/vets/foto.png" }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("envia a pasta na querystring e o arquivo no FormData", async () => {
+    const file = new File(["conteudo"], "foto.png", { type: "image/png" });
+
+    const result = await uploadImage("jwt", file, "vets");
+
+    expect(result).toEqual({ url: "https://s3/vets/foto.png" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/upload/image?folder=vets`);
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toMatchObject({ Authorization: "Bearer jwt" });
+    // FormData não vira JSON: sem isso o multipart perde o boundary do browser.
+    expect(init?.body).toBeInstanceOf(FormData);
+    expect((init?.body as FormData).get("file")).toBe(file);
+  });
+});

--- a/src/services/upload.service.ts
+++ b/src/services/upload.service.ts
@@ -1,0 +1,18 @@
+import { apiFetch } from "./api";
+
+export type UploadFolder = "pets" | "tutors" | "vets";
+
+export function uploadImage(
+  token: string,
+  file: File,
+  folder: UploadFolder,
+): Promise<{ url: string }> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  return apiFetch<{ url: string }>(`/upload/image?folder=${folder}`, {
+    method: "POST",
+    body: formData,
+    token,
+  });
+}

--- a/src/services/vet-profile.service.ts
+++ b/src/services/vet-profile.service.ts
@@ -4,6 +4,7 @@ export interface UpdateVeterinarioRequest {
   nome?: string;
   email?: string;
   telefone?: string;
+  crmv?: string;
   foto_url?: string;
 }
 

--- a/src/services/vet-profile.service.ts
+++ b/src/services/vet-profile.service.ts
@@ -1,0 +1,32 @@
+import { apiFetch } from "./api";
+
+export interface UpdateVeterinarioRequest {
+  nome?: string;
+  email?: string;
+  telefone?: string;
+  foto_url?: string;
+}
+
+/**
+ * A resposta do PATCH é o registro cru do banco (camelCase, com campos
+ * internos como `crmvVerifiedAt`) — não o mesmo formato do perfil logado.
+ * Por isso o retorno não é tipado: quem chama deve reconsultar
+ * `getVeterinarioProfile` para atualizar o que exibe.
+ */
+export function updateVeterinario(
+  token: string,
+  dto: UpdateVeterinarioRequest,
+): Promise<void> {
+  return apiFetch<void>("/veterinarios/me", {
+    method: "PATCH",
+    body: dto,
+    token,
+  });
+}
+
+export function deleteVeterinario(token: string): Promise<void> {
+  return apiFetch<void>("/veterinarios/me", {
+    method: "DELETE",
+    token,
+  });
+}


### PR DESCRIPTION
## Resumo
- Nova tela `/vet/profile`: trocar foto, editar nome/CRMV/e-mail/telefone, excluir conta (confirmação em duas etapas, sem clique único). Acessível pelo nome/foto do vet no cabeçalho do dashboard.
- `apiFetch` passa a aceitar `FormData` sem serializar para JSON, necessário pro upload de foto reaproveitar `POST /upload/image`.
- `AuthContext` ganha `refreshUser()`: depois de salvar, a tela reconsulta o perfil em vez de confiar na resposta do PATCH (formato diferente, com campos internos).
- CRMV editável no perfil avisa que a troca zera a verificação (regra já existente na api).
- Header do dashboard mostra a foto do vet ao lado do nome.
- `@petcardorg/shared` atualizado para `0.19.0` (traz `foto_url` em `UpdateVeterinarioDto`).

**Depende do [petcard-api#144](https://github.com/PetCardOrg/petcard-api/pull/144)** — sem a pasta `vets` liberada no upload e sem a correção de `foto_url`, o upload/edição de foto do vet não funciona fim a fim.

## Test plan
- [x] `npx vitest run` — 123 testes
- [x] `npx vitest run --coverage` — acima da catraca (84/80/73/84)
- [x] `npx eslint src --ext .ts,.tsx`
- [x] `npx tsc -b`
- [x] `npx vite build`
- [x] Testado manualmente contra a api local: login, editar nome/CRMV/e-mail/telefone (persiste após reload), trocar foto, exclusão de conta em duas etapas